### PR TITLE
rake 2d lists are flattened to a 1d array as hdf5 cannot store multi

### DIFF
--- a/SrfGen/createSRF.py
+++ b/SrfGen/createSRF.py
@@ -664,7 +664,7 @@ def CreateSRF_multi(nseg, seg_delay, mag0, mom0, rvfac_seg, gwid, rup_delay, \
         stoch_file = '%s/%s.stoch' % (stoch, os.path.basename(prefix))
         gen_stoch(stoch_file, joined_srf, silent = silent)
     # save INFO
-    gen_meta(joined_srf, 4, mag[0], stk, rak, dip, dt, \
+    gen_meta(joined_srf, 4, mag[0], stk, np.asarray(rak), dip, dt, \
             vm = velocity_model, dip_dir = dip_dir, \
             shypo = [s[0] + 0.5 * flen[c][0] for s in shypo], \
             dhypo = [d[0] for d in dhypo], tect_type = tect_type)


### PR DESCRIPTION
dimensional lists.
This does not cause issues as nothing reads the rake from the srf info
file, except when it is being read manually.
If in future it is desirable to use rakes from the srfinfo file then a
better solution must be found.