### PR TITLE
Change how filepaths are handled.

### DIFF
--- a/SrfGen/srfinfo2vm.py
+++ b/SrfGen/srfinfo2vm.py
@@ -740,7 +740,11 @@ def plot_vm(
         )
 
 
-def create_vm(args, srf_meta, logger: Logger = qclogging.get_basic_logger()):
+def create_vm(args, srf_meta, logger_name: str = None):
+    if logger_name is None:
+        logger = qclogging.get_basic_logger()
+    else:
+        logger = qclogging.get_logger(logger_name)
     # temp directory for current process
     ptemp = mkdtemp(prefix="_tmp_%s_" % (srf_meta["name"]), dir=args.out_dir)
 
@@ -968,7 +972,7 @@ def load_msgs(args, logger: Logger = qclogging.get_basic_logger()):
                         "mag": mag,
                         "hdepth": a["hdepth"],
                     },
-                    qclogging.get_realisation_logger(logger, name),
+                    qclogging.get_realisation_logger(logger, name).name,
                 )
             )
     return msgs
@@ -1030,7 +1034,7 @@ def load_msgs_nhm(args, logger: Logger = qclogging.get_basic_logger()):
                     "mag": mag,
                     "hdepth": dtop + 0.5 * (dbottom - dtop),
                 },
-                qclogging.get_realisation_logger(logger, n),
+                qclogging.get_realisation_logger(logger, n).name,
             )
         )
 
@@ -1201,27 +1205,14 @@ if __name__ == "__main__":
         )
         os.makedirs(args.out_dir)
 
-    # proxy function for mapping
-    def create_vm_star(args_meta):
-        return create_vm(*args_meta)
-
     # distribute work
-    if args.nproc > 1:
-        logger.debug(
-            "Number of processes to use given as {}, using multiple threads for the {} tasks to perform.".format(
-                args.nproc, len(msg_list)
-            )
+    logger.debug(
+        "Number of processes to use given as {}, number of tasks: {}.".format(
+            args.nproc, len(msg_list)
         )
-        p = Pool(processes=args.nproc)
-        reports = p.map(create_vm_star, msg_list)
-    else:
-        # debug friendly alternative
-        logger.debug(
-            "Number of processes to use given as {}, using one thread for the {} tasks to perform.".format(
-                args.nproc, len(msg_list)
-            )
-        )
-        reports = [create_vm_star(msg) for msg in msg_list]
+    )
+    p = Pool(processes=args.nproc)
+    reports = p.starmap(create_vm, msg_list)
 
     # nhm selection formatted file and list of excluded VMs
     if args.selection:

--- a/srf_generation/input_file_generation/generate_srf_from_realisations.py
+++ b/srf_generation/input_file_generation/generate_srf_from_realisations.py
@@ -17,7 +17,9 @@ from srf_generation.input_file_generation.realisation_to_srf import (
 def process_realisation_file(cybershake_root, realisation_file):
     rel_df: pd.DataFrame = pd.read_csv(realisation_file, dtype={"name": str})
     realisation = rel_df.to_dict(orient="records")[0]
-    stoch_file = simulation_structure.get_stoch_path(cybershake_root, realisation["name"])
+    stoch_file = simulation_structure.get_stoch_path(
+        cybershake_root, realisation["name"]
+    )
     if realisation["type"] == 1:
         create_ps_srf(realisation_file, realisation, stoch_file)
     sim_params_file = simulation_structure.get_source_params_path(

--- a/srf_generation/input_file_generation/generate_srf_from_realisations.py
+++ b/srf_generation/input_file_generation/generate_srf_from_realisations.py
@@ -17,8 +17,9 @@ from srf_generation.input_file_generation.realisation_to_srf import (
 def process_realisation_file(cybershake_root, realisation_file):
     rel_df: pd.DataFrame = pd.read_csv(realisation_file, dtype={"name": str})
     realisation = rel_df.to_dict(orient="records")[0]
+    stoch_file = simulation_structure.get_stoch_path(cybershake_root, realisation["name"])
     if realisation["type"] == 1:
-        create_ps_srf(cybershake_root, realisation)
+        create_ps_srf(realisation_file, realisation, stoch_file)
     sim_params_file = simulation_structure.get_source_params_path(
         cybershake_root, realisation["name"]
     )

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -135,7 +135,11 @@ def create_info_file(
         a["dbottom"] = dbottom
 
 
-def create_ps_srf(realisation_file: str, parameter_dictionary: Dict[str, Any], stoch_file: Union[None, str]=None):
+def create_ps_srf(
+    realisation_file: str,
+    parameter_dictionary: Dict[str, Any],
+    stoch_file: Union[None, str] = None,
+):
     latitude = parameter_dictionary.pop("latitude")
     longitude = parameter_dictionary.pop("longitude")
     depth = parameter_dictionary.pop("depth")

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -177,7 +177,7 @@ def create_ps_srf(
     ### file names
     ###
     srf_file = realisation_file.replace(".csv", ".srf")
-    gsf_file = NamedTemporaryFile(mode='w', delete=False)
+    gsf_file = NamedTemporaryFile(mode="w", delete=False)
 
     ###
     ### create GSF


### PR DESCRIPTION
If realisation_to_srf is run then all output files are placed adjacent to the realisation file
if generate_srf_from_realisations is run then output files are placed consistent with the cybershake directory structure
Also fix bug with attempting to pickle loggers for multiprocessed vm generation
srfinfo2vm no longer has special case for single threaded mode