### PR TITLE
Added srf generation seed realisation at realisation time so it's sav…

### DIFF
--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -20,7 +20,6 @@ from srf_generation.source_parameter_generation.uncertainties.common import (
     HF_RUN_PARAMS,
     BB_RUN_PARAMS,
     LF_RUN_PARAMS,
-    get_seed,
 )
 from srf_generation.source_parameter_generation.uncertainties.mag_scaling import (
     mag2mom,
@@ -180,6 +179,10 @@ def create_ps_srf(
     risetime = parameter_dictionary.pop("risetime", 0.5)
     inittime = parameter_dictionary.pop("inittime", 0.0)
 
+    # srfgen seed is not used by slip2srf (unless we pass rt_rand in),
+    # but we also don't need it to be in the sim_params.yaml file
+    parameter_dictionary.pop("srfgen_seed")
+
     name = parameter_dictionary.pop("name")
     logger.info(f"Generating srf for realisation {name}")
 
@@ -295,7 +298,7 @@ def create_ps_ff_srf(
     shypo = parameter_dictionary.pop("shypo")
     dhypo = parameter_dictionary.pop("dhypo")
     genslip_version = str(parameter_dictionary.pop("genslip_version"))
-    seed = parameter_dictionary.pop("seed", get_seed())
+    seed = parameter_dictionary.pop("srfgen_seed")
     slip_cov = parameter_dictionary.pop("slip_cov", None)
     rough = parameter_dictionary.pop("rough", None)
 

--- a/srf_generation/source_parameter_generation/gcmt_to_realisation.py
+++ b/srf_generation/source_parameter_generation/gcmt_to_realisation.py
@@ -22,7 +22,8 @@ from qcore.qclogging import (
 from srf_generation.source_parameter_generation.uncertainties.common import (
     GCMT_PARAM_NAMES,
     GCMT_Source,
-    get_seed)
+    get_seed,
+)
 from srf_generation.source_parameter_generation.uncertainties.versions import (
     load_perturbation_function,
 )

--- a/srf_generation/source_parameter_generation/gcmt_to_realisation.py
+++ b/srf_generation/source_parameter_generation/gcmt_to_realisation.py
@@ -22,7 +22,7 @@ from qcore.qclogging import (
 from srf_generation.source_parameter_generation.uncertainties.common import (
     GCMT_PARAM_NAMES,
     GCMT_Source,
-)
+    get_seed)
 from srf_generation.source_parameter_generation.uncertainties.versions import (
     load_perturbation_function,
 )
@@ -332,6 +332,8 @@ def generate_realisation(
         f"Got results from perturbation_function: {perturbed_realisation}"
     )
     perturbed_realisation["params"]["name"] = realisation_name
+    if "srfgen_seed" not in perturbed_realisation["params"]:
+        perturbed_realisation["params"]["srfgen_seed"] = get_seed()
 
     if (
         vel_mod_1d_dir is not None

--- a/srf_generation/source_parameter_generation/uncertainties/common.py
+++ b/srf_generation/source_parameter_generation/uncertainties/common.py
@@ -46,7 +46,7 @@ NHM_PARAM_NAMES = [
 ]
 NHM_Source = namedtuple("NHM_Source", NHM_PARAM_NAMES)
 
-GENERAL_PARAMS = ["name", "type", "genslip_version"]
+GENERAL_PARAMS = ["name", "type", "genslip_version", "srfgen_seed"]
 
 SRFGEN_TYPE_1_PARAMS = [
     "latitude",


### PR DESCRIPTION
…ed in the realisation file.

Type 1 srfgen can use a seed, but only if rt_rand is used instead of rtfac
As generate_realisation doesn't know what type of srf it's creating,
it can't be selective about which realisations get a seed