### PR TITLE
switched srf_version

### DIFF
--- a/SrfGen/createSRF.py
+++ b/SrfGen/createSRF.py
@@ -454,7 +454,7 @@ def gen_srf(
             "dhypo=%f" % (dhypo),
             "dt=%f" % dt,
             "plane_header=1",
-            "srf_version=2.0",
+            "srf_version=1.0",
         ]
         if rvfrac is not None:
             cmd.append("rvfrac=%s" % (rvfrac))


### PR DESCRIPTION
Some of our code can't parse version 2.0 of SRF format. So if we are using the latest version we need to make sure we are using version 1.0 rather than implicitly because we are on an old version.