### PR TITLE
Risetime parameters

### DIFF
--- a/SrfGen/createSRF.py
+++ b/SrfGen/createSRF.py
@@ -250,9 +250,9 @@ def focal_mechanism_2_finite_fault(
     # use cartesian coordinate system to define the along strike and downdip
     # locations taking the center of the fault plane as (x,y)=(0,0)
     xPos: np.ndarray = np.arange(DLEN / 2.0, fault_length, DLEN) - fault_length / 2.0
-    yPos: np.ndarray = np.arange(DWID / 2.0, fault_width, DWID)[
-        ::-1
-    ] - fault_width / 2.0
+    yPos: np.ndarray = (
+        np.arange(DWID / 2.0, fault_width, DWID)[::-1] - fault_width / 2.0
+    )
 
     # now use a coordinate transformation to go from fault plane to North and
     # East cartesian plane (again with (0,0) ==(0,0)  )

--- a/SrfGen/gen_coords.py
+++ b/SrfGen/gen_coords.py
@@ -23,8 +23,8 @@ def gen_coords(
     Generate coordinate files for an emod3d domain (set of grid points).
     outdir: directory to store coordinate files in
     debug: print additional info
-    geoproj: 
-    do_coords: 
+    geoproj:
+    do_coords:
     """
 
     logger.debug("Generating coords. VM directory: {}".format(vm_dir))

--- a/SrfGen/srfinfo2vm.py
+++ b/SrfGen/srfinfo2vm.py
@@ -372,7 +372,7 @@ def reduce_domain(
 ):
     """Reduces the domain of the VM by removing areas that are over sea only. Gives a buffer around coast line and the
     srf boundary. Returns the new values to be used.
-    Uses great circle geometry """
+    Uses great circle geometry"""
     # number of scan lines accross domain (inclusive of edges)
     scanlines = max(round(ylen / 5), 81)
 

--- a/srf_generation/Fault.py
+++ b/srf_generation/Fault.py
@@ -116,6 +116,25 @@ class Fault(ABC):
     def _set_rake(self, value):
         self._rake = value
 
+    @property
+    def dip(self):
+        return self._dip
+
+    @dip.setter
+    def dip(self, value):
+        if 90 < value < 180:
+            self.strike = self.strike + 180
+            self.rake = -self.rake
+            value = 180 - value
+        elif value < 0 or value > 180:
+            # The fault is now above ground
+            raise ValueError(f"Invalid dip value: {value}")
+
+        self._set_dip(value)
+
+    def _set_dip(self, value):
+        self._dip = value
+
 
 class SinglePlaneFault(Fault):
     def __init__(self, name, magnitude, strike, rake, dip):
@@ -137,20 +156,6 @@ class SinglePlaneFault(Fault):
     @strike.setter
     def strike(self, value):
         self._strike = value % 360
-
-    @property
-    def dip(self):
-        return self._dip
-
-    @dip.setter
-    def dip(self, value):
-        if 90 < value < 180:
-            self.strike = self.strike + 180
-            value = 180 - value
-        elif value < 0 or value > 180:
-            raise ValueError("Invalid dip value")
-
-        self._dip = value
 
     @property
     def dhypo(self):
@@ -664,3 +669,57 @@ class Type4(MultiPlaneFault):
             for key, item in sub_fault.to_dict().items():
                 base_dict[f"{key}_subfault_{i}"] = item
         return base_dict
+
+    @property
+    def trace(self):
+        points = [x._trace[0] for x in self._planes]
+        points.append(self._planes[-1]._trace[1])
+        return np.asarray(points)
+
+    @trace.setter
+    def trace(self, values):
+        for i in range(self._n_planes):
+            sub_plane = self._planes[i]
+            sub_plane._trace = (tuple(values[i]), tuple(values[i + 1]))
+
+    @property
+    def dtop(self):
+        return self._dtop
+
+    @dtop.setter
+    def dtop(self, value):
+        if value < 0:
+            raise ValueError("dtop must be below ground level")
+        self._dtop = value
+
+    @property
+    def dbottom(self):
+        return self._dbottom
+
+    @dbottom.setter
+    def dbottom(self, value):
+        if value < 0:
+            raise ValueError("dtop must be below ground level")
+        self._dbottom = value
+
+    @property
+    def dip_dir(self):
+        return self._dip_dir
+
+    @dip_dir.setter
+    def dip_dir(self, value):
+        self._dip_dir = value
+
+    def _set_dip(self, value):
+        for sub_fault in self._planes:
+            sub_fault.dip = value
+        self._dip = value
+
+    @property
+    def strike(self):
+        return np.asarray([x.strike for x in self._planes])
+
+    @strike.setter
+    def strike(self, values):
+        for i in range(self._n_planes):
+            self._planes[i].strike = values[i]

--- a/srf_generation/Fault.py
+++ b/srf_generation/Fault.py
@@ -459,9 +459,9 @@ class Type2(FiniteFault):
 
         # use cartesian coordinate system to define the along strike and downdip
         # locations taking the center of the fault plane as (x,y)=(0,0)
-        y_pos: np.ndarray = np.arange(self.dwid / 2.0, self.width, self.dwid)[
-            ::-1
-        ] - self.width / 2.0
+        y_pos: np.ndarray = (
+            np.arange(self.dwid / 2.0, self.width, self.dwid)[::-1] - self.width / 2.0
+        )
 
         depth_loc_relative = (
             (-y_pos * np.sin(np.radians(self._dip)))

--- a/srf_generation/plot_realisation_file_parameters.py
+++ b/srf_generation/plot_realisation_file_parameters.py
@@ -220,7 +220,9 @@ def plot_area_mag(
 
 
 def plot_area_nhm(
-    median_faults: Dict[str, pd.DataFrame], nhm_file: Dict[str, NHMFault], out_dir: str,
+    median_faults: Dict[str, pd.DataFrame],
+    nhm_file: Dict[str, NHMFault],
+    out_dir: str,
 ):
     srf_area = []
     fault_name = []
@@ -353,7 +355,9 @@ def plot_mag_nrup(
 
 
 def plot_dbottom(
-    info_files: List[str], nhm_data: Dict[str, NHMFault], out_dir: str,
+    info_files: List[str],
+    nhm_data: Dict[str, NHMFault],
+    out_dir: str,
 ):
 
     srf_depths = []
@@ -767,7 +771,8 @@ def plot_hypo_dist(
 
 
 def plot_srf_error(
-    info_files: List[str], out_dir: str,
+    info_files: List[str],
+    out_dir: str,
 ):
     # strike and dip error assuming 0.1km subfault spacing
     error_s = []

--- a/srf_generation/source_parameter_generation/nhm_to_realisation.py
+++ b/srf_generation/source_parameter_generation/nhm_to_realisation.py
@@ -265,7 +265,9 @@ def get_additional_source_parameters(
     :param nhm_data: A Dictionary of faults and their NHMFault objects
     :param vel_mod_1d_layers: A dataframe containing a row for every layer of the velocity model
     """
-    additional_source_parameters = pd.DataFrame(index=sorted(list(nhm_data.keys())),)
+    additional_source_parameters = pd.DataFrame(
+        index=sorted(list(nhm_data.keys())),
+    )
     for param_name, filepath in source_parameters:
         parameter_df = pd.read_csv(
             filepath,

--- a/srf_generation/source_parameter_generation/uncertainties/common.py
+++ b/srf_generation/source_parameter_generation/uncertainties/common.py
@@ -71,6 +71,17 @@ SRFGEN_TYPE_2_PARAMS = [
     "dhypo",
     "rvfac",
     "mwsr",
+    "risetime",
+    "risetime_coef",
+    "risetimefac",
+    "risetimedep",
+    "risetimedep_range",
+    "deep_risetimefac",
+    "deep_risetimedep",
+    "deep_risetimedep_range",
+    "rt_scalefac",
+    "rt_rand",
+    "stype",
 ]
 
 SRFGEN_TYPE_3_PARAMS = [
@@ -86,6 +97,17 @@ SRFGEN_TYPE_3_PARAMS = [
     "width",
     "strike",
     "dip_dir",
+    "risetime",
+    "risetime_coef",
+    "risetimefac",
+    "risetimedep",
+    "risetimedep_range",
+    "deep_risetimefac",
+    "deep_risetimedep",
+    "deep_risetimedep_range",
+    "rt_scalefac",
+    "rt_rand",
+    "stype",
 ]
 
 SRFGEN_TYPE_4_PARAMS = [
@@ -102,6 +124,17 @@ SRFGEN_TYPE_4_PARAMS = [
     "dip_dir",
     "shypo",
     "dhypo",
+    "risetime",
+    "risetime_coef",
+    "risetimefac",
+    "risetimedep",
+    "risetimedep_range",
+    "deep_risetimefac",
+    "deep_risetimedep",
+    "deep_risetimedep_range",
+    "rt_scalefac",
+    "rt_rand",
+    "stype",
 ]
 
 HF_RUN_PARAMS = [

--- a/srf_generation/source_parameter_generation/uncertainties/common.py
+++ b/srf_generation/source_parameter_generation/uncertainties/common.py
@@ -311,9 +311,9 @@ def focal_mechanism_2_finite_fault(lat, lon, depth, mag, strike, rake, dip, mwsr
     # use cartesian coordinate system to define the along strike and downdip
     # locations taking the center of the fault plane as (x,y)=(0,0)
     x_pos: np.ndarray = np.arange(dlen / 2.0, fault_length, dlen) - fault_length / 2.0
-    y_pos: np.ndarray = np.arange(dwid / 2.0, fault_width, dwid)[
-        ::-1
-    ] - fault_width / 2.0
+    y_pos: np.ndarray = (
+        np.arange(dwid / 2.0, fault_width, dwid)[::-1] - fault_width / 2.0
+    )
 
     lats, lons = calculate_corners(dip, x_pos, y_pos, lat, lon, strike)
 

--- a/srf_generation/source_parameter_generation/uncertainties/common.py
+++ b/srf_generation/source_parameter_generation/uncertainties/common.py
@@ -50,6 +50,10 @@ SRFGEN_TYPE_1_PARAMS = [
     "inittime",
     "target_slip_cm",
     "target_area_km",
+    "risetimefac",
+    "risetimedep",
+    "risetimedep_range",
+    "risetime_dipfac",
 ]
 
 SRFGEN_TYPE_2_PARAMS = [

--- a/srf_generation/source_parameter_generation/uncertainties/distributions.py
+++ b/srf_generation/source_parameter_generation/uncertainties/distributions.py
@@ -1,7 +1,7 @@
 import random
 
 import numpy as np
-from scipy.stats import truncnorm
+from scipy.stats import truncnorm, weibull_min
 
 
 def relative_uniform(mean, scale_factor):
@@ -20,6 +20,18 @@ def truncated_normal(mean, std_dev, std_dev_limit=2):
     )
 
 
+def bounded_truncated_normal(mean, upper_limit, lower_limit):
+    dist_range = upper_limit - lower_limit
+    return float(
+        truncnorm(
+            (mean - lower_limit) / dist_range,
+            (upper_limit - mean) / dist_range,
+            loc=mean,
+            scale=dist_range,
+        ).rvs()
+    )
+
+
 def weibull(k=3.353, scale_factor=0.612):
     """Weibull distribution. Defaults are for nhm2srf dhypo generation"""
     return scale_factor * np.random.weibull(k)
@@ -35,6 +47,21 @@ def truncated_weibull(truncation_threshold, k=3.353, scale_factor=0.612):
     return return_value
 
 
+def proper_weibull(k=3.353, scale_factor=0.612):
+    return weibull_min(c=k, scale=scale_factor).rvs()
+
+
+def proper_truncated_weibull(upper_truncation_threshold, lower_truncation_threshold, k=3.353, scale_factor=0.612):
+    dist = weibull_min(c=k, scale=scale_factor)
+    upper_value, lower_value = dist.cdf((upper_truncation_threshold, lower_truncation_threshold))
+    dist_range = upper_value - lower_value
+    val = (dist.cdf(np.random.uniform(lower_truncation_threshold, upper_truncation_threshold))-lower_value)/dist_range
+    # if val < lower_truncation_threshold or val > upper_truncation_threshold:
+    #     print("Broken")
+    # print(val, dist_range, upper_value, lower_value, upper_truncation_threshold, lower_truncation_threshold)
+    return val
+
+
 def truncated_log_normal(mean, std_dev, std_dev_limit=2) -> float:
     return np.exp(
         truncnorm(
@@ -42,6 +69,18 @@ def truncated_log_normal(mean, std_dev, std_dev_limit=2) -> float:
             std_dev_limit,
             loc=np.log(np.asarray(mean).astype(np.float)),
             scale=std_dev,
+        ).rvs()
+    )
+
+
+def bounded_truncated_log_normal(mean, upper_limit, lower_limit) -> float:
+    dist_range = upper_limit - lower_limit
+    return np.exp(
+        truncnorm(
+            (mean - lower_limit) / dist_range,
+            (upper_limit - mean) / dist_range,
+            loc=np.log(np.asarray(mean).astype(np.float)),
+            scale=dist_range,
         ).rvs()
     )
 

--- a/srf_generation/source_parameter_generation/uncertainties/distributions.py
+++ b/srf_generation/source_parameter_generation/uncertainties/distributions.py
@@ -51,11 +51,20 @@ def proper_weibull(k=3.353, scale_factor=0.612):
     return weibull_min(c=k, scale=scale_factor).rvs()
 
 
-def proper_truncated_weibull(upper_truncation_threshold, lower_truncation_threshold, k=3.353, scale_factor=0.612):
+def proper_truncated_weibull(
+    upper_truncation_threshold, lower_truncation_threshold, k=3.353, scale_factor=0.612
+):
     dist = weibull_min(c=k, scale=scale_factor)
-    upper_value, lower_value = dist.cdf((upper_truncation_threshold, lower_truncation_threshold))
+    upper_value, lower_value = dist.cdf(
+        (upper_truncation_threshold, lower_truncation_threshold)
+    )
     dist_range = upper_value - lower_value
-    val = (dist.cdf(np.random.uniform(lower_truncation_threshold, upper_truncation_threshold))-lower_value)/dist_range
+    val = (
+        dist.cdf(
+            np.random.uniform(lower_truncation_threshold, upper_truncation_threshold)
+        )
+        - lower_value
+    ) / dist_range
     # if val < lower_truncation_threshold or val > upper_truncation_threshold:
     #     print("Broken")
     # print(val, dist_range, upper_value, lower_value, upper_truncation_threshold, lower_truncation_threshold)

--- a/srf_generation/source_parameter_generation/uncertainties/mag_scaling.py
+++ b/srf_generation/source_parameter_generation/uncertainties/mag_scaling.py
@@ -232,7 +232,12 @@ def lw_2_mw_sigma_scaling_relation(
     """
     sigma = None
     # magnitude
-    mw = lw_2_mw_scaling_relation(l, w, mw_scaling_rel, rake,)
+    mw = lw_2_mw_scaling_relation(
+        l,
+        w,
+        mw_scaling_rel,
+        rake,
+    )
     if mw_scaling_rel == MagnitudeScalingRelations.LEONARD2014:
         sigma = mw_sigma_leonard(rake)
     elif mw_scaling_rel == MagnitudeScalingRelations.SKARLATOUDIS2016:

--- a/srf_generation/source_parameter_generation/uncertainties/versions/V19p8.py
+++ b/srf_generation/source_parameter_generation/uncertainties/versions/V19p8.py
@@ -22,14 +22,14 @@ def generate_source_params(
     **kwargs,
 ) -> Dict[str, Any]:
     """source_data should have the following parameters available via . notation:
-      - source_data.pid: name of the event
-      - source_data.lat: latitude
-      - source_data.lon: longitude
-      - source_data.depth
-      - source_data.mag: magnitude
-      - source_data.strike
-      - source_data.dip
-      - source_data.rake
+    - source_data.pid: name of the event
+    - source_data.lat: latitude
+    - source_data.lon: longitude
+    - source_data.depth
+    - source_data.mag: magnitude
+    - source_data.strike
+    - source_data.dip
+    - source_data.rake
     """
 
     realisation = kwargs

--- a/srf_generation/source_parameter_generation/uncertainties/versions/cs_20_4.py
+++ b/srf_generation/source_parameter_generation/uncertainties/versions/cs_20_4.py
@@ -30,14 +30,14 @@ def generate_source_params(
     **kwargs
 ) -> Dict[str, Any]:
     """source_data should have the following parameters available via . notation:
-      - source_data.pid: name of the event
-      - source_data.lat: latitude
-      - source_data.lon: longitude
-      - source_data.depth
-      - source_data.mag: magnitude
-      - source_data.strike
-      - source_data.dip
-      - source_data.rake
+    - source_data.pid: name of the event
+    - source_data.lat: latitude
+    - source_data.lon: longitude
+    - source_data.depth
+    - source_data.mag: magnitude
+    - source_data.strike
+    - source_data.dip
+    - source_data.rake
     """
 
     fault: Type4 = fault_factory(TYPE)(source_data)

--- a/srf_generation/source_parameter_generation/uncertainties/versions/gcmt_1.py
+++ b/srf_generation/source_parameter_generation/uncertainties/versions/gcmt_1.py
@@ -19,14 +19,14 @@ def generate_source_params(
     **kwargs
 ) -> Dict[str, Any]:
     """source_data should have the following parameters available via . notation:
-      - source_data.pid: name of the event
-      - source_data.lat: latitude
-      - source_data.lon: longitude
-      - source_data.depth
-      - source_data.mag: magnitude
-      - source_data.strike
-      - source_data.dip
-      - source_data.rake
+    - source_data.pid: name of the event
+    - source_data.lat: latitude
+    - source_data.lon: longitude
+    - source_data.depth
+    - source_data.mag: magnitude
+    - source_data.strike
+    - source_data.dip
+    - source_data.rake
     """
 
     fault: Type1 = fault_factory(TYPE)(

--- a/srf_generation/source_parameter_generation/uncertainties/versions/gcmt_2.py
+++ b/srf_generation/source_parameter_generation/uncertainties/versions/gcmt_2.py
@@ -25,14 +25,14 @@ def generate_source_params(
     **kwargs,
 ) -> Dict[str, Any]:
     """source_data should have the following parameters available via . notation:
-      - source_data.pid: name of the event
-      - source_data.lat: latitude
-      - source_data.lon: longitude
-      - source_data.depth: depth
-      - source_data.mag: magnitude
-      - source_data.strike
-      - source_data.dip
-      - source_data.rake
+    - source_data.pid: name of the event
+    - source_data.lat: latitude
+    - source_data.lon: longitude
+    - source_data.depth: depth
+    - source_data.mag: magnitude
+    - source_data.strike
+    - source_data.dip
+    - source_data.rake
     """
     additional_source_parameters = filter_realisation_input_params(
         TYPE, additional_source_parameters

--- a/srf_generation/source_parameter_generation/uncertainties/versions/nhm_3.py
+++ b/srf_generation/source_parameter_generation/uncertainties/versions/nhm_3.py
@@ -20,14 +20,14 @@ def generate_source_params(
     **kwargs
 ) -> Dict[str, Any]:
     """source_data should have the following parameters available via . notation:
-      - source_data.pid: name of the event
-      - source_data.lat: latitude
-      - source_data.lon: longitude
-      - source_data.depth
-      - source_data.mag: magnitude
-      - source_data.strike
-      - source_data.dip
-      - source_data.rake
+    - source_data.pid: name of the event
+    - source_data.lat: latitude
+    - source_data.lon: longitude
+    - source_data.depth
+    - source_data.mag: magnitude
+    - source_data.strike
+    - source_data.dip
+    - source_data.rake
     """
 
     fault: Type4 = fault_factory(TYPE)(source_data)

--- a/srf_generation/source_parameter_generation/uncertainties/versions/nhm_4.py
+++ b/srf_generation/source_parameter_generation/uncertainties/versions/nhm_4.py
@@ -25,14 +25,14 @@ def generate_source_params(
     **kwargs
 ) -> Dict[str, Any]:
     """source_data should have the following parameters available via . notation:
-      - source_data.pid: name of the event
-      - source_data.lat: latitude
-      - source_data.lon: longitude
-      - source_data.depth
-      - source_data.mag: magnitude
-      - source_data.strike
-      - source_data.dip
-      - source_data.rake
+    - source_data.pid: name of the event
+    - source_data.lat: latitude
+    - source_data.lon: longitude
+    - source_data.depth
+    - source_data.mag: magnitude
+    - source_data.strike
+    - source_data.dip
+    - source_data.rake
     """
 
     fault: Type4 = fault_factory(TYPE)(source_data)

--- a/srf_generation/source_parameter_generation/uncertainties/versions/sjn_realisations_203.py
+++ b/srf_generation/source_parameter_generation/uncertainties/versions/sjn_realisations_203.py
@@ -13,14 +13,14 @@ from srf_generation.source_parameter_generation.uncertainties.mag_scaling import
 
 def generate_source_params(source_data: GCMT_Source) -> Dict[str, Any]:
     """source_data should have the following parameters available via . notation:
-      - source_data.pid: name of the event
-      - source_data.lat: latitude
-      - source_data.lon: longitude
-      - source_data.depth: depth
-      - source_data.mag: magnitude
-      - source_data.strike
-      - source_data.dip
-      - source_data.rake
+    - source_data.pid: name of the event
+    - source_data.lat: latitude
+    - source_data.lon: longitude
+    - source_data.depth: depth
+    - source_data.mag: magnitude
+    - source_data.strike
+    - source_data.dip
+    - source_data.rake
     """
 
     params = generate_from_gcmt(source_data)


### PR DESCRIPTION
Can now edit the risetime parameters for srf generation.
Type 1 generation has one multiplier taper, which defaults from 2* at 5km to 1* at 8km
Type 2-4 generation has two multiplier tapers, which default t o2* at 5km to 1* at 8km and 1* at 15km to 2* at 20km