### PR TITLE
Revert change. Not sure why original change was made

### DIFF
--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -226,7 +226,7 @@ def create_ps_srf(
             aa = np.exp(2.0 / 3.0 * np.log(moment) - 14.7 * np.log(10.0))
         dd = np.sqrt(aa)
         slip = (moment * 1.0e-20) / (aa * vs * vs * rho)
-    dd = np.round(dd)
+
     logger.debug(f"Slip: {slip}, fault plane edge length {dd}")
 
     ###


### PR DESCRIPTION
This change broke previous behaviour as faults generated with rounded edge lengths instead of the length calculated from the mom->area formula
e.g. 2122842 had an edge length of 2.0 instead of 1.7783 as per original Validation generated srfs