### PR TITLE
dbottom was added to type2 gen for VMgen

### DIFF
--- a/srf_generation/source_parameter_generation/uncertainties/common.py
+++ b/srf_generation/source_parameter_generation/uncertainties/common.py
@@ -86,6 +86,7 @@ SRFGEN_TYPE_2_PARAMS = [
     "rt_scalefac",
     "rt_rand",
     "stype",
+    "dbottom",
 ]
 
 SRFGEN_TYPE_3_PARAMS = [


### PR DESCRIPTION
This is part of my checks to ensure that version files only add things that are useful to the realisation file
Mostly to prevent spelling mistakes etc, rather than stop weird things going in though