### PR TITLE
Bug hunt: Like duck hunt but with less annoying dog

### DIFF
--- a/srf_generation/source_parameter_generation/generate_realisations_from_gcmt.py
+++ b/srf_generation/source_parameter_generation/generate_realisations_from_gcmt.py
@@ -316,7 +316,7 @@ def main():
 
     if args.aggregate_file is not None:
         ordered_rels = [
-            get_realisation_name(pid, i + 1) for pid in pids for i in faults[pid]
+            get_realisation_name(pid, i + 1) for pid in pids for i in range(faults[pid])
         ]
 
         agg = pd.read_csv(args.aggregate_file)


### PR DESCRIPTION
faults is a {str:int} dict, with the number of realisations for each event/fault in it.
I have no idea why it tried iterating over the int and not the range in the first place
NHMs don't generate this aggregation file, so don't have the issue