### PR TITLE
To represent % in a string, it needs %%

### DIFF
--- a/VM/rel2vm_params.py
+++ b/VM/rel2vm_params.py
@@ -1074,7 +1074,7 @@ def load_args():
     )
     arg(
         "--target-land-coverage",
-        help="Land coverage level (%) that triggers optimisation if not met (Default: 99.0)",
+        help="Land coverage level (%%) that triggers optimisation if not met (Default: 99.0)",
         type=float,
         default=None,
     )


### PR DESCRIPTION
This error occurred with --help option
```
python VM/rel2vm_params.py --help
Traceback (most recent call last):
  File "VM/rel2vm_params.py", line 1121, in <module>
    args = load_args()
  File "VM/rel2vm_params.py", line 1094, in load_args
    args = parser.parse_args()
  File "/usr/lib/python3.8/argparse.py", line 1768, in parse_args
    args, argv = self.parse_known_args(args, namespace)
  File "/usr/lib/python3.8/argparse.py", line 1800, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/usr/lib/python3.8/argparse.py", line 2006, in _parse_known_args
    start_index = consume_optional(start_index)
  File "/usr/lib/python3.8/argparse.py", line 1946, in consume_optional
    take_action(action, args, option_string)
  File "/usr/lib/python3.8/argparse.py", line 1874, in take_action
    action(self, namespace, argument_values, option_string)
  File "/usr/lib/python3.8/argparse.py", line 1044, in __call__
    parser.print_help()
  File "/usr/lib/python3.8/argparse.py", line 2494, in print_help
    self._print_message(self.format_help(), file)
  File "/usr/lib/python3.8/argparse.py", line 2478, in format_help
    return formatter.format_help()
  File "/usr/lib/python3.8/argparse.py", line 282, in format_help
    help = self._root_section.format_help()
  File "/usr/lib/python3.8/argparse.py", line 213, in format_help
    item_help = join([func(*args) for func, args in self.items])
  File "/usr/lib/python3.8/argparse.py", line 213, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
  File "/usr/lib/python3.8/argparse.py", line 213, in format_help
    item_help = join([func(*args) for func, args in self.items])
  File "/usr/lib/python3.8/argparse.py", line 213, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
  File "/usr/lib/python3.8/argparse.py", line 529, in _format_action
    help_text = self._expand_help(action)
  File "/usr/lib/python3.8/argparse.py", line 621, in _expand_help
    return self._get_help_string(action) % params
ValueError: unsupported format character ')' (0x29) at index 23
```