### PR TITLE
If outdir is not specified, use the dir containing vm_params.yaml

### DIFF
--- a/VM/vm_params2vm.py
+++ b/VM/vm_params2vm.py
@@ -226,7 +226,7 @@ def load_args(logger: Logger = qclogging.get_basic_logger()):
         "-o",
         "--outdir",
         help="output directory to place VM files "
-        "(if not specified, the same path as rel_file is used",
+        "(if not specified, the directory containing vm_params.yaml is used",
         default=None,
     )
 


### PR DESCRIPTION
vm_params2vm.py had a wrong help for argument --outdir.
If no outdir is specified, use the directory that contains vm_params.yaml, not rel file.