### PR TITLE
rand_shyp is in the range [-0.5, 0.5]

### DIFF
--- a/srf_generation/source_parameter_generation/uncertainties/versions/nhm_4.py
+++ b/srf_generation/source_parameter_generation/uncertainties/versions/nhm_4.py
@@ -37,7 +37,7 @@ def generate_source_params(
 
     fault: Type4 = fault_factory(TYPE)(source_data)
 
-    fault.shypo = fault.length / 2 * rand_shyp()
+    fault.shypo = fault.length * rand_shyp()
     fault.dhypo = fault.width * truncated_weibull(1)
 
     params = fault.to_dict()


### PR DESCRIPTION
This means the shyp was being double halved, and therefore restricted to the middle half of faults