### PR TITLE
fixed bug with consistency with srfinfo

### DIFF
--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -606,7 +606,7 @@ def create_multi_plane_srf(
         dt,
         tect_type=tect_type,
         dip_dir=dip_dir,
-        shypo=[shypo + 0.5 * flen[0]],
+        shypo=[shypo],
         dhypo=dhypo,
         vm=vel_mod_1d,
         logger=rel_logger,


### PR DESCRIPTION
This change makes the srfinfo shypo values the same as what is stored in the rel_csv aka internally consistent.