### PR TITLE
Fix spelling

### DIFF
--- a/srf_generation/plot_realisation_file_parameters.py
+++ b/srf_generation/plot_realisation_file_parameters.py
@@ -194,7 +194,7 @@ def plot_area_mag(
         plt.plot(
             ds_mw_mean,
             a_to_mw_leonard(ds_area_mean, 4, 3.99, 90),
-            label="Actual (dip slip) (unperturbated)",
+            label="Actual (dip slip) (unperturbed)",
             marker="x",
             linestyle="None",
         )
@@ -209,7 +209,7 @@ def plot_area_mag(
         plt.plot(
             ss_mw_mean,
             a_to_mw_leonard(ss_area_mean, 4, 3.99, 180),
-            label="Actual (strike slip) (unperturbated)",
+            label="Actual (strike slip) (unperturbed)",
             marker="x",
             linestyle="None",
         )

--- a/srf_generation/source_parameter_generation/common.py
+++ b/srf_generation/source_parameter_generation/common.py
@@ -67,7 +67,7 @@ def add_common_arguments(parser, single_event=True):
         vs30_parser.add_argument(
             "--vs30_out",
             type=abspath,
-            help="The path to a file to save the perturbated VS30s to",
+            help="The path to a file to save the perturbed VS30s to",
             default=abspath("."),
         )
     else:

--- a/srf_generation/source_parameter_generation/gcmt_to_realisation.py
+++ b/srf_generation/source_parameter_generation/gcmt_to_realisation.py
@@ -154,7 +154,7 @@ def generate_fault_realisations(
     realisation_count: int,
     output_directory: str,
     perturbation_function: Callable,
-    unperturbation_function: Callable,
+    unperturbed_function: Callable,
     aggregate_file: Union[str, None],
     vel_mod_1d: pd.DataFrame,
     vel_mod_1d_dir: str,
@@ -189,13 +189,13 @@ def generate_fault_realisations(
             fault_logger,
         )
 
-    if perturbation_function != unperturbation_function:
-        unperturbated_realisation = unperturbation_function(
+    if perturbation_function != unperturbed_function:
+        unperturbed_realisation = unperturbed_function(
             source_data=data,
             additional_source_parameters=additional_source_parameters,
             vel_mod_1d=None,
         )
-        rel_df = pd.DataFrame(unperturbated_realisation, index=[0])
+        rel_df = pd.DataFrame(unperturbed_realisation, index=[0])
         realisation_file_name = join(output_directory, f"{fault_name}.csv")
         rel_df.to_csv(realisation_file_name, index=False)
 
@@ -256,9 +256,9 @@ def generate_realisation(
         perturbed_realisation["params"]["v_mod_1d_name"] = file_name_1d_vel_mod
 
     if vs30_out_file is not None and "vs30" in perturbed_realisation.keys():
-        perturbated_vs30: pd.DataFrame = perturbed_realisation.pop("vs30")
+        perturbed_vs30: pd.DataFrame = perturbed_realisation.pop("vs30")
         makedirs(dirname(vs30_out_file), exist_ok=True)
-        perturbated_vs30.to_csv(
+        perturbed_vs30.to_csv(
             vs30_out_file, columns=["vs30"], sep=" ", index=True, header=False
         )
         perturbed_realisation["params"]["vs30_file_path"] = vs30_out_file
@@ -275,7 +275,7 @@ def generate_realisation(
         perturbed_realisation["params"]["asperity_file"] = asperity_file_path
 
     fault_logger.debug(
-        f"Created Srf directory and attempting to save perturbated source generation parameters there: {realisation_file_name}"
+        f"Created Srf directory and attempting to save perturbed source generation parameters there: {realisation_file_name}"
     )
     rel_df = pd.DataFrame(perturbed_realisation["params"], index=[0])
     rel_df.to_csv(realisation_file_name, index=False)
@@ -345,7 +345,7 @@ def main():
     args = load_args(primary_logger)
 
     perturbation_function = load_perturbation_function(args.version)
-    unperturbation_function = load_perturbation_function(f"gcmt_{args.version}")
+    unperturbed_function = load_perturbation_function(f"gcmt_{args.version}")
     primary_logger.debug(f"Perturbation function loaded. Version: {args.version}")
 
     gcmt_data = pd.read_csv(args.gcmt_file, usecols=GCMT_FILE_COLUMNS, index_col=0)[
@@ -394,7 +394,7 @@ def main():
             args.realisation_count,
             args.output_dir,
             perturbation_function,
-            unperturbation_function,
+            unperturbed_function,
             args.aggregate_file,
             vel_mod_1d_layers,
             args.vel_mod_1d_out,

--- a/srf_generation/source_parameter_generation/generate_realisations_from_gcmt.py
+++ b/srf_generation/source_parameter_generation/generate_realisations_from_gcmt.py
@@ -108,7 +108,7 @@ def generate_fault_realisations(
     realisation_count: int,
     cybershake_root: str,
     perturbation_function: Callable,
-    unperturbation_function: Callable,
+    unperturbed_function: Callable,
     aggregate_file: Union[str, None],
     vel_mod_1d: pd.DataFrame,
     vs30_data: pd.DataFrame,
@@ -178,13 +178,13 @@ def generate_fault_realisations(
             fault_logger,
         )
 
-    if perturbation_function != unperturbation_function:
-        unperturbated_realisation = unperturbation_function(
+    if perturbation_function != unperturbed_function:
+        unperturbed_realisation = unperturbed_function(
             source_data=data,
             additional_source_parameters=additional_source_parameters,
             vel_mod_1d=None,
         )
-        rel_df = pd.DataFrame(unperturbated_realisation["params"], index=[0])
+        rel_df = pd.DataFrame(unperturbed_realisation["params"], index=[0])
         realisation_file_name = join(
             get_sources_dir(cybershake_root), fault_name, f"{fault_name}.csv"
         )
@@ -198,7 +198,7 @@ def generate_messages(
     faults,
     gcmt_lines,
     perturbation_function,
-    unperturbation_function,
+    unperturbed_function,
     vel_mod_1d,
     checkpointing,
     vs30_data: pd.DataFrame,
@@ -222,7 +222,7 @@ def generate_messages(
                 faults[fault_name],
                 cybershake_root,
                 perturbation_function,
-                unperturbation_function,
+                unperturbed_function,
                 aggregate_file,
                 vel_mod_1d,
                 vs30_data,
@@ -241,7 +241,7 @@ def main():
     args = load_args(primary_logger)
 
     perturbation_function = load_perturbation_function(args.version)
-    unperturbation_function = load_perturbation_function(f"gcmt_{args.type}")
+    unperturbed_function = load_perturbation_function(f"gcmt_{args.type}")
     primary_logger.debug(f"Perturbation function loaded. Version: {args.version}")
 
     faults = load_fault_selection_file(args.fault_selection_file)
@@ -291,7 +291,7 @@ def main():
         faults,
         gcmt_lines,
         perturbation_function,
-        unperturbation_function,
+        unperturbed_function,
         velocity_model_1d,
         args.checkpointing,
         vs30,

--- a/srf_generation/source_parameter_generation/generate_realisations_from_nhm.py
+++ b/srf_generation/source_parameter_generation/generate_realisations_from_nhm.py
@@ -66,8 +66,9 @@ def load_args(primary_logger: Logger):
         help="The number of processes to run at once. Capped at the number of events to generate realisations for.",
         default=1,
     )
+    parser.add_argument("type", type=str, help="The type of srf to generate.", default="4", nargs="?")
     parser.add_argument(
-        "--unperturbated_version",
+        "--unperturbed_version",
         type=str,
         help="The name of the base version which doesn't have perturbations. "
         "Should be the name of the file without the .py suffix.",
@@ -111,7 +112,7 @@ def generate_fault_realisations(
     realisation_count: int,
     cybershake_root: str,
     perturbation_function: Callable,
-    unperturbation_function: Callable,
+    unperturbed_function: Callable,
     aggregate_file: Union[str, None],
     vel_mod_1d: pd.DataFrame,
     vs30_data: pd.DataFrame,
@@ -181,13 +182,13 @@ def generate_fault_realisations(
             fault_logger,
         )
 
-    if perturbation_function != unperturbation_function:
-        unperturbated_realisation = unperturbation_function(
+    if perturbation_function != unperturbed_function:
+        unperturbed_realisation = unperturbed_function(
             source_data=data,
             additional_source_parameters=additional_source_parameters,
             vel_mod_1d=None,
         )
-        rel_df = pd.DataFrame(unperturbated_realisation["params"], index=[0])
+        rel_df = pd.DataFrame(unperturbed_realisation["params"], index=[0])
         realisation_file_name = join(
             get_sources_dir(cybershake_root), fault_name, f"{fault_name}.csv"
         )
@@ -201,7 +202,7 @@ def generate_messages(
     faults,
     nhm_faults,
     perturbation_function,
-    unperturbation_function,
+    unperturbed_function,
     vel_mod_1d,
     checkpointing,
     vs30_data: pd.DataFrame,
@@ -224,7 +225,7 @@ def generate_messages(
                 faults[fault_name],
                 cybershake_root,
                 perturbation_function,
-                unperturbation_function,
+                unperturbed_function,
                 aggregate_file,
                 vel_mod_1d,
                 vs30_data,
@@ -243,7 +244,10 @@ def main():
     args = load_args(primary_logger)
 
     perturbation_function = load_perturbation_function(args.version)
-    unperturbation_function = load_perturbation_function(args.unperturbated_version)
+    if args.unperturbed_version is None:
+        unperturbed_function = load_perturbation_function(f"nhm_{args.type}")
+    else:
+        unperturbed_function = load_perturbation_function(args.unperturbed_version)
     primary_logger.debug(f"Perturbation function loaded. Version: {args.version}")
 
     faults = load_fault_selection_file(args.fault_selection_file)
@@ -285,7 +289,7 @@ def main():
         faults,
         nhm_faults,
         perturbation_function,
-        unperturbation_function,
+        unperturbed_function,
         velocity_model_1d,
         args.checkpointing,
         vs30,

--- a/srf_generation/source_parameter_generation/nhm_to_realisation.py
+++ b/srf_generation/source_parameter_generation/nhm_to_realisation.py
@@ -123,7 +123,7 @@ def generate_fault_realisations(
     realisation_count: int,
     output_directory: str,
     perturbation_function: Callable,
-    unperturbation_function: Callable,
+    unperturbed_function: Callable,
     aggregate_file: Union[str, None],
     vel_mod_1d: pd.DataFrame,
     vel_mod_1d_dir: str,
@@ -158,13 +158,13 @@ def generate_fault_realisations(
             fault_logger,
         )
 
-    if perturbation_function != unperturbation_function:
-        unperturbated_realisation = unperturbation_function(
+    if perturbation_function != unperturbed_function:
+        unperturbed_realisation = unperturbed_function(
             source_data=data,
             additional_source_parameters=additional_source_parameters,
             vel_mod_1d=None,
         )
-        rel_df = pd.DataFrame(unperturbated_realisation, index=[0])
+        rel_df = pd.DataFrame(unperturbed_realisation, index=[0])
         realisation_file_name = join(output_directory, f"{fault_name}.csv")
         rel_df.to_csv(realisation_file_name, index=False)
 
@@ -225,8 +225,8 @@ def generate_realisation(
         perturbed_realisation["params"]["v_mod_1d_name"] = file_name_1d_vel_mod
 
     if vs30_out_file is not None and "vs30" in perturbed_realisation.keys():
-        perturbated_vs30: pd.DataFrame = perturbed_realisation["vs30"]
-        perturbated_vs30.to_csv(
+        perturbed_vs30: pd.DataFrame = perturbed_realisation["vs30"]
+        perturbed_vs30.to_csv(
             vs30_out_file, columns="vs30", sep=" ", index=True, header=False
         )
         perturbed_realisation["params"]["vs30_file_path"] = vs30_out_file
@@ -243,7 +243,7 @@ def generate_realisation(
         perturbed_realisation["params"]["asperity_file"] = asperity_file_path
 
     fault_logger.debug(
-        f"Created Srf directory and attempting to save perturbated source generation parameters there: {realisation_file_name}"
+        f"Created Srf directory and attempting to save perturbed source generation parameters there: {realisation_file_name}"
     )
     rel_df = pd.DataFrame(perturbed_realisation["params"], index=[0])
     rel_df.to_csv(realisation_file_name, index=False)
@@ -304,7 +304,7 @@ def main():
     args = load_args(primary_logger)
 
     perturbation_function = load_perturbation_function(args.version)
-    unperturbation_function = load_perturbation_function(f"nhm_{args.type}")
+    unperturbed_function = load_perturbation_function(f"nhm_{args.type}")
     primary_logger.debug(f"Perturbation function loaded. Version: {args.version}")
 
     nhm_data = load_nhm(args.nhm_file)
@@ -350,7 +350,7 @@ def main():
             args.realisation_count,
             args.output_dir,
             perturbation_function,
-            unperturbation_function,
+            unperturbed_function,
             args.aggregate_file,
             vel_mod_1d_layers,
             args.vel_mod_1d_out,

--- a/srf_generation/velocity_model_generation/generate_3d_velocity_model_perturbation.py
+++ b/srf_generation/velocity_model_generation/generate_3d_velocity_model_perturbation.py
@@ -25,7 +25,7 @@ LAYER_GENERATION_ERROR_TEXT = (
 )
 
 
-def create_perturbated_layer(
+def create_perturbed_layer(
     index,
     nx,
     ny,
@@ -124,7 +124,7 @@ def generate_velocity_model_perturbation_file_from_config(
     set_verbose(verbose)
 
     complete_layer_parameters = [
-        (create_perturbated_layer, dict({"index": index}, **l_p, **common_params))
+        (create_perturbed_layer, dict({"index": index}, **l_p, **common_params))
         for index, l_p in layer_params.items()
     ]
     if n_processes == 1:
@@ -214,7 +214,7 @@ def generate_velocity_model_perturbation_file_from_model(
         if n_processes == 1:
             layer_info = sorted(
                 [
-                    create_perturbated_layer(*layer)
+                    create_perturbed_layer(*layer)
                     for layer in complete_layer_parameters
                 ]
             )
@@ -223,7 +223,7 @@ def generate_velocity_model_perturbation_file_from_model(
                 with Pool(n_processes) as pool:
                     layer_info = sorted(
                         pool.starmap(
-                            create_perturbated_layer, complete_layer_parameters
+                            create_perturbed_layer, complete_layer_parameters
                         )
                     )
             except AssertionError:

--- a/srf_generation/velocity_model_generation/generate_perturbation_file.py
+++ b/srf_generation/velocity_model_generation/generate_perturbation_file.py
@@ -45,7 +45,7 @@ def load_args():
     parser.add_argument(
         "--perturbation",
         action="store_true",
-        help="Generate perturbated layers using Rob Graves Fractal3D code. If not used a base perturbation file of 1s will be used",
+        help="Generate perturbed layers using Rob Graves Fractal3D code. If not used a base perturbation file of 1s will be used",
     )
     parser.add_argument(
         "--fault_damage_zone",


### PR DESCRIPTION
Bring script arguments back into parity with gcmt, without losing added funcitonality