### PR TITLE
Fix: argument's data type matched to function signature

### DIFF
--- a/srf_generation/source_parameter_generation/nhm_to_realisation.py
+++ b/srf_generation/source_parameter_generation/nhm_to_realisation.py
@@ -277,7 +277,7 @@ def main():
     additional_source_parameters = get_additional_source_parameters(
         args.source_parameter,
         args.common_source_parameter,
-        fault_nhm,
+        {fault_nhm.name: fault_nhm},
         vel_mod_1d_layers,
     )
 


### PR DESCRIPTION
It seems we don't usually run nhm_to_realisation directly, so this bug stayed unnoticed.
```
def get_additional_source_parameters(
    source_parameters: List[Tuple[str, str]],
    common_source_parameters: List[Tuple[str, str]],
    nhm_data: Dict[str, NHMFault],  <----
    vel_mod_1d_layers: pd.DataFrame,
):
```
`fault_nhm` is an object of NHMFault, so calling this function use to crash. 