### PR TITLE
Fixed: when rel num is 0, it crashes when sorting agg file

### DIFF
--- a/srf_generation/source_parameter_generation/generate_realisations_from_gcmt.py
+++ b/srf_generation/source_parameter_generation/generate_realisations_from_gcmt.py
@@ -299,11 +299,12 @@ def main():
         worker_pool.starmap(generate_fault_realisations, messages)
 
     if args.aggregate_file is not None:
-        ordered_rels = [
-            get_realisation_name(pid, i + 1) if faults[pid] > 1 else pid
-            for pid in pids
-            for i in range(faults[pid])
-        ]
+        ordered_rels = []
+        for pid in pids:
+            if faults[pid] == 0:
+                ordered_rels.append(pid)
+            else:
+                ordered_rels.extend([get_realisation_name(pid, i + 1) for i in range(faults[pid])])
 
         agg = pd.read_csv(args.aggregate_file)
         agg.sort_values(

--- a/srf_generation/source_parameter_generation/generate_realisations_from_gcmt.py
+++ b/srf_generation/source_parameter_generation/generate_realisations_from_gcmt.py
@@ -304,7 +304,9 @@ def main():
             if faults[pid] == 0:
                 ordered_rels.append(pid)
             else:
-                ordered_rels.extend([get_realisation_name(pid, i + 1) for i in range(faults[pid])])
+                ordered_rels.extend(
+                    [get_realisation_name(pid, i + 1) for i in range(faults[pid])]
+                )
 
         agg = pd.read_csv(args.aggregate_file)
         agg.sort_values(


### PR DESCRIPTION
When rel num is 0, the selection file has no second column, the ordered_rels list is supposed to collect the fault names.

However, faults[pid] is 0, and the list comprehension is never executed and ordered_rels becomes an empty list.
This patch fixes the issue.