### PR TITLE
mkdtemp has no cleanup()

### DIFF
--- a/VM/vm_params2vm.py
+++ b/VM/vm_params2vm.py
@@ -210,7 +210,7 @@ def main(
         )
     else:
         logger.debug("vm_params.yaml has no data for VM generation")
-    tempd.cleanup()
+    rmtree(tempd)
     logger.debug(f"{temp_dir} removed")
 
 


### PR DESCRIPTION
My bad - my earlier PR (https://github.com/ucgmsim/Pre-processing/pull/221) had a bug.

mkdtemp returns a path in string format, and doesn't have cleanup() function unlike TemporaryDirectory.