### PR TITLE
FIX: If rel name is all-number, SRF gen fails

### DIFF
--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -852,9 +852,6 @@ def main():
     qclogging.add_general_file_handler(primary_logger, "rel2srf.txt")
     args = load_args()
     realisation = load_realisation_file_as_dict(args.realisation_file)
-    realisation["name"] = str(
-        realisation["name"]
-    )  # str() to avoid all-number name becoming an integer
     rel_logger = qclogging.get_realisation_logger(primary_logger, realisation["name"])
     if realisation["type"] == 1:
         create_ps_srf(args.realisation_file, realisation, logger=rel_logger)

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -852,6 +852,7 @@ def main():
     qclogging.add_general_file_handler(primary_logger, "rel2srf.txt")
     args = load_args()
     realisation = load_realisation_file_as_dict(args.realisation_file)
+    realisation["name"]=str(realisation["name"])  #str() to avoid all-number name becoming an integer
     rel_logger = qclogging.get_realisation_logger(primary_logger, realisation["name"])
     if realisation["type"] == 1:
         create_ps_srf(args.realisation_file, realisation, logger=rel_logger)

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -852,7 +852,9 @@ def main():
     qclogging.add_general_file_handler(primary_logger, "rel2srf.txt")
     args = load_args()
     realisation = load_realisation_file_as_dict(args.realisation_file)
-    realisation["name"]=str(realisation["name"])  #str() to avoid all-number name becoming an integer
+    realisation["name"] = str(
+        realisation["name"]
+    )  # str() to avoid all-number name becoming an integer
     rel_logger = qclogging.get_realisation_logger(primary_logger, realisation["name"])
     if realisation["type"] == 1:
         create_ps_srf(args.realisation_file, realisation, logger=rel_logger)

--- a/srf_generation/pre_processing_common.py
+++ b/srf_generation/pre_processing_common.py
@@ -49,6 +49,9 @@ ONE_DEG_LAT = np.radians(6371.0072)
 def load_realisation_file_as_dict(file_name):
     rel_df: pd.DataFrame = pd.read_csv(file_name)
     realisation = rel_df.to_dict(orient="records")[0]
+    realisation["name"] = str(
+        realisation["name"]
+    )  # str() to avoid all-number name becoming an integer
     return realisation
 
 


### PR DESCRIPTION
This issue was found while tech-supporting Mike.
When a realisation name is all numbers, SRF gen was failing
```
        2020p806446_REL01 |         SRF_GEN |  completed | 40773862 |  2023-11-08 23:53:36
                  2192455 |         SRF_GEN |     failed | 40772343 |  2023-11-08 23:06:43
            2192455_REL01 |         SRF_GEN |  completed | 40773243 |  2023-11-08 23:38:03
                  2474759 |         SRF_GEN |     failed | 40772346 |  2023-11-08 23:06:43
            2474759_REL01 |         SRF_GEN |  completed | 40773258 |  2023-11-08 23:38:29
                  2625245 |         SRF_GEN |     failed | 40772348 |  2023-11-08 23:06:43
            2625245_REL01 |         SRF_GEN |  completed | 40773262 |  2023-11-08 23:38:55
                  2808393 |         SRF_GEN |     failed | 40772350 |  2023-11-08 23:06:43
            2808393_REL01 |         SRF_GEN |  completed | 40773263 |  2023-11-08 23:38:55
```
One of the log gave me a clue:
![image (7)](https://github.com/ucgmsim/Pre-processing/assets/466989/cda8622b-8816-4da2-bd96-2f358d355bf2)

Indeed, this was easy to reproduce.
```
>>> import logging
>>> logging.getLogger(2192455)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/sungbae/mambaforge/lib/python3.10/logging/__init__.py", line 2079, in getLogger
    return Logger.manager.getLogger(name)
  File "/Users/sungbae/mambaforge/lib/python3.10/logging/__init__.py", line 1328, in getLogger
    raise TypeError('A logger name must be a string')
TypeError: A logger name must be a string
>>> logging.getLogger("2192455")
<Logger 2192455 (WARNING)>
```
Hence this fix.