### PR TITLE
FIX: If VM pert from conf, layerX.pertb files are created in CS root dir

### DIFF
--- a/VM/vm_params2vm.py
+++ b/VM/vm_params2vm.py
@@ -210,7 +210,7 @@ def main(
         )
     else:
         logger.debug("vm_params.yaml has no data for VM generation")
-    tempd.cleanup()
+    rmtree(tempd)
     logger.debug(f"{temp_dir} removed")
 
 

--- a/srf_generation/velocity_model_generation/generate_3d_velocity_model_perturbation.py
+++ b/srf_generation/velocity_model_generation/generate_3d_velocity_model_perturbation.py
@@ -143,7 +143,7 @@ def generate_velocity_model_perturbation_file_from_config(
         except AssertionError:
             print("The process failed at the layer generation, try with n_proc=1")
             raise
-    combine_layers(layer_info, common_params["nx"], common_params["ny"], out_file)
+    combine_layers(layer_info, common_params["nx"], common_params["ny"], out_file, temp_dir_path)
     for _, _, file in layer_info:
         remove(file)
     temp_dir.cleanup()

--- a/srf_generation/velocity_model_generation/generate_3d_velocity_model_perturbation.py
+++ b/srf_generation/velocity_model_generation/generate_3d_velocity_model_perturbation.py
@@ -167,7 +167,6 @@ def generate_velocity_model_perturbation_file_from_model(
     # Uses a temp dir in the current folder structure due to memory issues if using an actual temp directory
     with TemporaryDirectory(dir=Path(out_file).parent) as temp_dir:
         temp_dir_path = Path(temp_dir).resolve()
-
         complete_layer_parameters = []
         while current_depth < max_depth:
             layer = perturbation_model.iloc[i]

--- a/srf_generation/velocity_model_generation/generate_3d_velocity_model_perturbation.py
+++ b/srf_generation/velocity_model_generation/generate_3d_velocity_model_perturbation.py
@@ -123,16 +123,17 @@ def generate_velocity_model_perturbation_file_from_config(
 ):
     set_verbose(verbose)
 
-
     temp_dir = TemporaryDirectory(dir=Path(out_file).parent)
     temp_dir_path = Path(temp_dir.name).resolve()
 
     complete_layer_parameters = [
-        (create_perturbed_layer, dict({"index": index, "temp_dir":  temp_dir_path}, **l_p, **common_params))
+        (
+            create_perturbed_layer,
+            dict({"index": index, "temp_dir": temp_dir_path}, **l_p, **common_params),
+        )
         for index, l_p in layer_params.items()
     ]
 
-    print(complete_layer_parameters)
     if n_processes == 1:
         layer_info = sorted([kwarg_map(*layer) for layer in complete_layer_parameters])
     else:
@@ -146,6 +147,7 @@ def generate_velocity_model_perturbation_file_from_config(
     for _, _, file in layer_info:
         remove(file)
     temp_dir.cleanup()
+
 
 def set_verbose(verbose):
     if verbose:

--- a/srf_generation/velocity_model_generation/generate_3d_velocity_model_perturbation.py
+++ b/srf_generation/velocity_model_generation/generate_3d_velocity_model_perturbation.py
@@ -143,7 +143,9 @@ def generate_velocity_model_perturbation_file_from_config(
         except AssertionError:
             print("The process failed at the layer generation, try with n_proc=1")
             raise
-    combine_layers(layer_info, common_params["nx"], common_params["ny"], out_file, temp_dir_path)
+    combine_layers(
+        layer_info, common_params["nx"], common_params["ny"], out_file, temp_dir_path
+    )
     for _, _, file in layer_info:
         remove(file)
     temp_dir.cleanup()

--- a/srf_generation/velocity_model_generation/generate_3d_velocity_model_perturbation.py
+++ b/srf_generation/velocity_model_generation/generate_3d_velocity_model_perturbation.py
@@ -123,10 +123,16 @@ def generate_velocity_model_perturbation_file_from_config(
 ):
     set_verbose(verbose)
 
+
+    temp_dir = TemporaryDirectory(dir=Path(out_file).parent)
+    temp_dir_path = Path(temp_dir.name).resolve()
+
     complete_layer_parameters = [
-        (create_perturbed_layer, dict({"index": index}, **l_p, **common_params))
+        (create_perturbed_layer, dict({"index": index, "temp_dir":  temp_dir_path}, **l_p, **common_params))
         for index, l_p in layer_params.items()
     ]
+
+    print(complete_layer_parameters)
     if n_processes == 1:
         layer_info = sorted([kwarg_map(*layer) for layer in complete_layer_parameters])
     else:
@@ -139,7 +145,7 @@ def generate_velocity_model_perturbation_file_from_config(
     combine_layers(layer_info, common_params["nx"], common_params["ny"], out_file)
     for _, _, file in layer_info:
         remove(file)
-
+    temp_dir.cleanup()
 
 def set_verbose(verbose):
     if verbose:
@@ -159,6 +165,7 @@ def generate_velocity_model_perturbation_file_from_model(
     # Uses a temp dir in the current folder structure due to memory issues if using an actual temp directory
     with TemporaryDirectory(dir=Path(out_file).parent) as temp_dir:
         temp_dir_path = Path(temp_dir).resolve()
+
         complete_layer_parameters = []
         while current_depth < max_depth:
             layer = perturbation_model.iloc[i]


### PR DESCRIPTION
When VM pert is done as a part of CS workflow and VM pert from config is what you want to do (opposed to from model), it creates layer0.pertb, layer1.pertb... temporary files in the CS root directory.

```
-rw-rw----+   1 baes  nesi00213    10620000 Nov 22 23:26 layer0.pertb
-rw-rw----+   1 baes  nesi00213    42480000 Nov 22 23:26 layer1.pertb
-rw-rw----+   1 baes  nesi00213    31860000 Nov 22 23:26 layer2.pertb
..
-rw-rw----+   1 baes  nesi00213    95580000 Nov 22 23:26 layer3.pertb.cplx
```

When there are multiple VM pert jobs running at the same time, this causes multiple processes trying to read/write the temporary file of the same name in the same location. As a result, many of VM pert jobs would crash, producing core files in the CS root directory.

This can be fixed by creating a temporary directory where the perturbation file is created. 

This issue was investigated in this slack thread: https://uceqeng.slack.com/archives/C03V84ZD21H/p1700690478089329