### PR TITLE
Clean up realisation to SRF generation code (WIP)

### DIFF
--- a/VM/models/AfshariStewart_2016_Ds.py
+++ b/VM/models/AfshariStewart_2016_Ds.py
@@ -43,6 +43,7 @@ Output Variables:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 """
+
 import numpy as np
 
 from VM.models.classdef import FaultStyle
@@ -129,13 +130,11 @@ def Afshari_Stewart_2016_Ds(siteprop, faultprop, im):
 
     # Japan
     MuZ1 = np.exp(
-        -5.23 / 2 * np.log((v30**2 + 412.39**2) / (1360**2 + 412.39**2))
-        - np.log(1000)
+        -5.23 / 2 * np.log((v30**2 + 412.39**2) / (1360**2 + 412.39**2)) - np.log(1000)
     )
     # California
     MuZ1 = np.exp(
-        -7.15 / 4 * np.log((v30**4 + 570.94**4) / (1360**4 + 570.94**4))
-        - np.log(1000)
+        -7.15 / 4 * np.log((v30**4 + 570.94**4) / (1360**4 + 570.94**4)) - np.log(1000)
     )
 
     delta_z1 = Z1p0 - MuZ1

--- a/VM/models/Bradley_2010_Sa.py
+++ b/VM/models/Bradley_2010_Sa.py
@@ -63,6 +63,7 @@ Output Variables:
 Issues:
 
 """
+
 # from numba import jit
 
 import numpy as np

--- a/VM/plot_vm.py
+++ b/VM/plot_vm.py
@@ -152,10 +152,10 @@ def main(
             origin, vm_params_dict["MODEL_ROT"], xlen, ylen
         )
 
-        vm_params_dict[
-            "path_mod"
-        ] = "{:.6f}\t{:.6f}\n{:.6f}\t{:.6f}\n{:.6f}\t{:.6f}\n{:.6f}\t{:.6f}\n".format(
-            c1[0], c1[1], c2[0], c2[1], c3[0], c3[1], c4[0], c4[1]
+        vm_params_dict["path_mod"] = (
+            "{:.6f}\t{:.6f}\n{:.6f}\t{:.6f}\n{:.6f}\t{:.6f}\n{:.6f}\t{:.6f}\n".format(
+                c1[0], c1[1], c2[0], c2[1], c3[0], c3[1], c4[0], c4[1]
+            )
         )
         vm_params_dict["path"] = vm_params_dict["path_mod"]
         vm_params_dict["adjusted"] = False

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -10,7 +10,7 @@ from logging import Logger
 from os import makedirs, path
 from subprocess import PIPE, Popen, run
 from tempfile import NamedTemporaryFile
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Union, TextIO
 
 import numpy as np
 import yaml
@@ -910,7 +910,7 @@ def gen_srf(
 
 
 def gen_gsf(
-    gsfp: str,
+    gsf_handle: TextIO,
     lon: float,
     lat: float,
     dtop: float,
@@ -927,7 +927,8 @@ def gen_gsf(
 
     Parameters
     ----------
-    gsfp: File path for the GSF file.
+    gsf_handle: File handle for the GSF file. Must come from NamedTemporaryFile
+    because it must have the `name` property.
 
     lon   |
     lat   |
@@ -942,11 +943,11 @@ def gen_gsf(
     ny: TODO
     logger: optional alternative logger for log output.
     """
-    logger.debug(f"Saving gsf to {gsfp.name}")
+    logger.debug(f"Saving gsf to {gsf_handle.name}")
     with Popen(
         [binary_version.get_unversioned_bin(FAULTSEG2GSFDIPDIR), "read_slip_vals=0"],
         stdin=PIPE,
-        stdout=gsfp,
+        stdout=gsf_handle,
     ) as gexec:
         gexec.communicate(
             f"1\n{lon:f} {lat:f} {dtop:f} {strike} {dip} {rake} {flen:f} {fwid:f} {nx:d} {ny:d}".encode(

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -5,6 +5,7 @@ The parameters that are read from the CSV file are documented on the
 [wiki](https://wiki.canterbury.ac.nz/display/QuakeCore/File+Formats+Used+On+GM).
 """
 
+from pathlib import Path
 import argparse
 from logging import Logger
 from os import makedirs, path
@@ -1001,7 +1002,7 @@ def load_args() -> argparse.Namespace:
     A Namespace object containing the command line arguments (as specified by parse_args).
     """
     parser = argparse.ArgumentParser()
-    parser.add_argument("realisation_file", type=path.abspath)
+    parser.add_argument("realisation_file", type=Path)
     return parser.parse_args()
 
 

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -77,8 +77,8 @@ def create_stoch(
     Parameters
     ----------
     stoch_file: The filepath to output the stoch file.
-    srf_file: The filepath of the SRF file
-    single_segment: TODO
+    srf_file: The filepath of the SRF file.
+    single_segment: True if the stoch file is a single segment.
     logger: optional alternative logger for log output.
     """
     logger.debug("Generating stoch file")
@@ -101,7 +101,7 @@ def create_stoch(
 
 def get_corners_dbottom(planes: Dict[str, Any], dip_dir: Union[str, None] = None):
     """
-    TODO
+    Get projected bottom corners of the planes for info file output.
 
     Parameters
     ----------
@@ -122,13 +122,13 @@ def get_corners_dbottom(planes: Dict[str, Any], dip_dir: Union[str, None] = None
     dbottom = []
     corners = np.zeros((len(planes), 4, 2))
     for i, p in enumerate(planes):
-        # currently only support single dip dir value TODO: is this true?
+        # currently only support single dip dir value
         if dip_dir is not None:
             dip_deg = dip_dir
         else:
             dip_deg = p["strike"] + 90
 
-        # projected fault width (along dip direction) TODO: more descriptive comment here (but it does need a comment)
+        # projected fault width (along dip direction)
         pwid = p["width"] * np.cos(np.radians(p["dip"]))
         corners[i, 0] = geo.ll_shift(
             p["centre"][1], p["centre"][0], p["length"] / 2.0, p["strike"] + 180
@@ -189,7 +189,7 @@ def create_info_file(
 
     lon: longitude of the centroid.
     lat: latitude of the centroid.
-    dip_dir: TODO | Directory of something?
+    dip_dir: direction of dip
     file_name: File path to save metadata
     logger: Logger for debug output
     """
@@ -204,7 +204,7 @@ def create_info_file(
     logger.debug(f"Saving info file to {file_name}")
     with h5py.File(file_name, "w") as h:
         a = h.attrs
-        # only taken from given parameters TODO: ???
+        # only taken from given parameters
         a["type"] = srf_type
         a["dt"] = dt
         a["rake"] = rake
@@ -286,8 +286,7 @@ def create_ps_srf(
         logger.debug("moment is negative, calculating from magnitude")
         moment = mag_scaling.mag2mom(magnitude)
 
-    # size (dd) and slip TODO: what is this comment saying?
-    # TODO: Why is this random calculation here?
+    # size (dd) and slip
     if target_area_km is not None:
         logger.debug(
             f"target_area_km given ({target_area_km}), using it to calculate fault edge length and slip"
@@ -752,8 +751,6 @@ def write_corners(filename: str, hypocentre: np.ndarray, corners: np.ndarray):
         cf.write(CORNERS_HEADER[0])
         cf.write(f"{hypocentre[0]} {hypocentre[1]}\n")
         cf.write(CORNERS_HEADER[1])
-        # 0 1 - draw in order to close box
-        # 2 3 TODO: bad explanation of the file format
         for i in [0, 1, 3, 2, 0]:
             cf.write(f"{corners[i, 0]:f} {corners[i, 1]:f}\n")
 
@@ -790,7 +787,7 @@ def gen_srf(
     Parameters
     ----------
     srf_file: The output srf file.
-    gsf_file: The input gsf file (TODO).
+    gsf_file: The input gsf file.
 
     type           |
     magnitude      |
@@ -808,9 +805,9 @@ def gen_srf(
     risetime_coef  |
     tect_type      |
 
-    fault_planes:  TODO | Number of fault planes?
-    asperity_file: TODO
-    xseg: TODO | Segments for type 4 simulations?
+    fault_planes: Number of fault planes.
+    asperity_file: Slip file location.
+    xseg: Segments for type 4 simulations.
 
     logger: optional alternative logger for log output.
     """

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -119,7 +119,7 @@ def create_stoch(
     logger.debug(f"{srf2stoch} stderr: {proc.stderr}")
 
 
-def get_corners_dbottom(planes: dict, dip_dir: Union[str, None] = None):
+def get_corners_dbottom(planes: Dict[str, Any], dip_dir: Union[str, None] = None):
     """
     TODO
 

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -751,7 +751,7 @@ def write_corners(filename: str, hypocentre: np.ndarray, corners: np.ndarray):
     hypocentre: The hypocentre of the eruption.
     corners: The bounds of the finite fault (as described in `get_corners`)
     """
-    with open(filename, "w") as cf:
+    with open(filename, "w", encoding="utf-8") as cf:
         # lines beginning with '>' are ignored
         cf.write(CORNERS_HEADER[0])
         cf.write(f"{hypocentre[0]} {hypocentre[1]}\n")
@@ -904,7 +904,7 @@ def gen_srf(
         cmd.append("read_slip_file=1")
         cmd.append(f"init_slip_file={asperity_file}")
     logger.debug(f"Creating SRF with command: {' '.join(cmd)}")
-    with open(srf_file, "w") as srfp:
+    with open(srf_file, "w", encoding="utf-8") as srfp:
         proc = run(cmd, stdout=srfp, stderr=PIPE, check=True)
     logger.debug(f"{genslip_bin} stderr: {proc.stderr}")
 
@@ -994,7 +994,7 @@ def generate_sim_params_yaml(
 
     logger.debug(f"Processed sim params: {sim_params}")
     logger.debug(f"Saving sim params to {sim_params_file}")
-    with open(sim_params_file, "w") as spf:
+    with open(sim_params_file, "w", encoding="utf-8") as spf:
         yaml.dump(sim_params, spf)
     logger.debug("Sim params saved")
 

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -45,19 +45,24 @@ CORNERS_HEADER = (
 )
 
 
-def get_n(fault_size: float, sub_fault_size: float) -> int:
-    """Get the number of subfaults for simulation TODO
+def number_subdivisions(fault_size: float, subdivision_size: float) -> int:
+    """
+    Calculate the number of meshgrid subdivisions for each fault plane.
 
     Parameters
     ----------
-    fault_size: Size of the fault.
-    sub_fault_size: Size of the subfaults.
+    fault_size : float
+        The size of the fault.
+    subdivision_size : float
+        The size of each subgrid
 
     Returns
     -------
-    The number of subfaults within the fault. TODO
+    int
+        The number of subdivisions
     """
-    return round(fault_size / sub_fault_size)
+
+    return round(fault_size / subdivision_size)
 
 
 def create_stoch(
@@ -438,8 +443,8 @@ def create_ps_ff_srf(
     logger.debug("Saving corners and hypocentre")
     write_corners(corners_file, hypocentre, corners)
 
-    nx = get_n(flen, dlen)
-    ny = get_n(fwid, dwid)
+    nx = number_subdivisions(flen, dlen)
+    ny = number_subdivisions(fwid, dwid)
 
     with NamedTemporaryFile(mode="w", delete=False) as gsfp:
         gen_gsf(
@@ -573,8 +578,8 @@ def create_multi_plane_srf(
 
     dlen = dwid = SRF_SUBFAULT_SIZE_KM
 
-    nx = [get_n(flen[i], dlen) for i in range(plane_count)]
-    ny = get_n(fwid[0], dwid)
+    nx = [number_subdivisions(flen[i], dlen) for i in range(plane_count)]
+    ny = number_subdivisions(fwid[0], dwid)
 
     if (
         utils.compare_versions(genslip_version, "5.4.2") < 0
@@ -911,8 +916,8 @@ def gen_gsf(
     rake: float,
     flen: float,
     fwid: float,
-    nx: float,
-    ny: float,
+    nstk: float,
+    ndip: float,
     logger: Logger = qclogging.get_basic_logger(),
 ):
     """Wrapper around the fault_seg2gsf_dipdir binary.
@@ -925,14 +930,13 @@ def gen_gsf(
     lon   |
     lat   |
     dtop  |
-    strike| Refer to wiki (see module documentation for link).
+    strike|
     dip   |
-    rake  |
+    rake  | Refer to wiki (see module documentation for link).
     flen  |
     fwid  |
-
-    nx: TODO
-    ny: TODO
+    nstk  |
+    ndip  |
     logger: optional alternative logger for log output.
     """
     logger.debug(f"Saving gsf to {gsf_handle.name}")
@@ -942,7 +946,7 @@ def gen_gsf(
         stdout=gsf_handle,
     ) as gexec:
         gexec.communicate(
-            f"1\n{lon:f} {lat:f} {dtop:f} {strike} {dip} {rake} {flen:f} {fwid:f} {nx:d} {ny:d}".encode(
+            f"1\n{lon:f} {lat:f} {dtop:f} {strike} {dip} {rake} {flen:f} {fwid:f} {nstk:d} {ndip:d}".encode(
                 "utf-8"
             )
         )

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -1,21 +1,20 @@
 import argparse
 from logging import Logger
-from subprocess import run, PIPE, Popen
-from typing import Dict, Any, Union, List
+from os import makedirs, path
+from subprocess import PIPE, Popen, run
 from tempfile import NamedTemporaryFile
+from typing import Any, Dict, List, Union
 
+import numpy as np
 import yaml
 from h5py import File as h5open
-import numpy as np
-from os import makedirs, path, remove
-from qcore import binary_version, srf, geo, qclogging, utils
-from qcore.utils import compare_versions
+from qcore import binary_version, geo, qclogging, srf, utils
 from qcore.uncertainties.mag_scaling import (
-    mag2mom,
     MagnitudeScalingRelations,
+    mag2mom,
     mw_to_a_skarlatoudis,
 )
-
+from qcore.utils import compare_versions
 from srf_generation.pre_processing_common import (
     calculate_corners,
     get_hypocentre,

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -74,7 +74,7 @@ def create_stoch(
         command = [srf2stoch, f"dx={dx}", f"dy={dy}"]
     command.extend([f"infile={srf_file}", f"outfile={stoch_file}"])
     logger.debug(f"Creating stoch with command: {command}")
-    proc = run(command, stderr=PIPE)
+    proc = run(command, stderr=PIPE, check=True)
     logger.debug(f"{srf2stoch} stderr: {proc.stderr}")
 
 
@@ -287,7 +287,7 @@ def create_ps_srf(
         "risetimefac=1.0",
         "risetimedep=0.0",
     ]
-    run(commands, stderr=PIPE)
+    run(commands, stderr=PIPE, check=True)
 
     ###
     ### save STOCH
@@ -767,7 +767,7 @@ def gen_srf(
         cmd.append(f"init_slip_file={asperity_file}")
     logger.debug("Creating SRF with command: {}".format(" ".join(cmd)))
     with open(srf_file, "w") as srfp:
-        proc = run(cmd, stdout=srfp, stderr=PIPE)
+        proc = run(cmd, stdout=srfp, stderr=PIPE, check=True)
     logger.debug(f"{genslip_bin} stderr: {proc.stderr}")
 
 

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -36,12 +36,10 @@ GENERICSLIP2SRF = "generic_slip2srf"
 FAULTSEG2GSFDIPDIR = "fault_seg2gsf_dipdir"
 
 CORNERS_HEADER = (
-    "> header line here for specifics \n\
-> This is the standard input file format where the \
-hypocenter is first then for each \n\
->Hypocenter (reference??) \n",
-    "> Below are the corners \
-(first point repeated as fifth to close box \n",
+    """> header line here for specifics
+> This is the standard input file format where the hypocenter is first then for each
+> Hypocenter (reference??) """,
+    "> Below are the corners (first point repeated as fifth to close box)\n",
 )
 
 

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -8,7 +8,6 @@ The parameters that are read from the CSV file are documented on the
 import argparse
 import os
 import subprocess
-from subprocess import Popen
 from logging import Logger
 from tempfile import NamedTemporaryFile
 from typing import Any, Dict, List, TextIO, Union, Tuple
@@ -982,7 +981,7 @@ def gen_gsf(
 
     """
     logger.debug(f"Saving gsf to {gsf_handle.name}")
-    with Popen(
+    with subprocess.Popen(
         [binary_version.get_unversioned_bin(FAULTSEG2GSFDIPDIR), "read_slip_vals=0"],
         stdin=subprocess.PIPE,
         stdout=gsf_handle,

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -24,11 +24,10 @@ from srf_generation.source_parameter_generation.common import (
     DEFAULT_1D_VELOCITY_MODEL_PATH,
 )
 from srf_generation.source_parameter_generation.uncertainties.common import (
-    HF_RUN_PARAMS,
     BB_RUN_PARAMS,
+    HF_RUN_PARAMS,
     LF_RUN_PARAMS,
 )
-
 
 SRF_SUBFAULT_SIZE_KM = 0.1
 

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -703,11 +703,12 @@ def get_corners(
     (lon, lat) pairs  representing coordinates in the WGS84 coordinate system.
     The indices 0, 1, 2, 3 correspond to the corners of the fault in the
     following fashion.
-                  fwid
+
+                  flen
             0 +------------+ 1
               |            |
               |            |
-              |            | flen
+              |            | fwid
               |            |
             2 +------------+ 3
     """
@@ -728,7 +729,8 @@ def write_corners(filename: str, hypocentre: np.ndarray, corners: np.ndarray):
     """
     Write a corners text file (used to plot faults).
 
-    The format of the corners file given a hypocentre [lonc, latc] an array of corners [[lon0, lat0], ..., [lon3, lat3]] is as follows
+    The format of the corners file given a hypocentre [lonc, latc] and an array
+    of corners [[lon0, lat0], ..., [lon3, lat3]] is as follows
 
     ```
     OUTPUT_PREHEADER # see CORNERS_HEADER[0]

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -678,9 +678,6 @@ def create_multi_plane_srf(
         f"Generated srf for realisation {name}. Moving to next available realisation."
     )
 
-    # path to resulting SRF
-    return srf_file
-
 
 def get_corners(
     lat: float, lon: float, flen: float, fwid: float, dip: float, strike: float

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -320,15 +320,15 @@ def create_ps_srf(
     ### create GSF
     ###
     with NamedTemporaryFile(mode="w+", delete=False) as gsfp:
-        gsfp.write("# nstk= 1 ndip= 1\n")
-        gsfp.write(f"# flen= {dd:10.4f} fwid= {dd:10.4f}\n")
-        gsfp.write(
-            "# LON  LAT  DEP(km)  SUB_DX  SUB_DY  LOC_STK  LOC_DIP  LOC_RAKE  SLIP(cm)  INIT_TIME  SEG_NO\n"
-        )
-        gsfp.write("1\n")
-        gsfp.write(
-            f"{longitude:11.5f} {latitude:11.5f} {depth:8.4f} {dd:8.4f} {dd:8.4f} "
-            f"{strike:6.1f} {dip:6.1f} {rake:6.1f} {slip:8.2f} {inittime:8.3f}    0\n"
+        gsfp.writelines(
+            [
+                "# nstk= 1 ndip= 1",
+                f"# flen= {dd:10.4f} fwid= {dd:10.4f}",
+                "# LON  LAT  DEP(km)  SUB_DX  SUB_DY  LOC_STK  LOC_DIP  LOC_RAKE  SLIP(cm)  INIT_TIME  SEG_NO",
+                "1",
+                f"{longitude:11.5f} {latitude:11.5f} {depth:8.4f} {dd:8.4f} {dd:8.4f} {strike:6.1f} {dip:6.1f} {rake:6.1f} {slip:8.2f} {inittime:8.3f}    0",
+                "",
+            ]
         )
 
     ###

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -10,15 +10,14 @@ import os
 import subprocess
 from logging import Logger
 from tempfile import NamedTemporaryFile
-from typing import Any, Dict, List, TextIO, Union, Tuple
+from typing import Any, Dict, List, TextIO, Tuple, Union
 
+import h5py
 import numpy as np
 import yaml
-import h5py
 from qcore import binary_version, geo, qclogging, srf, utils
 from qcore.uncertainties import mag_scaling
 from qcore.uncertainties.mag_scaling import MagnitudeScalingRelations
-from qcore.utils import compare_versions
 from srf_generation import pre_processing_common
 from srf_generation.source_parameter_generation.common import (
     DEFAULT_1D_VELOCITY_MODEL_PATH,
@@ -855,13 +854,13 @@ def gen_srf(
 
     genslip_bin = binary_version.get_genslip_bin(genslip_version)
     if (
-        compare_versions(genslip_version, "5.4.2") < 0
+        utils.compare_versions(genslip_version, "5.4.2") < 0
         and tect_type == "SUBDUCTION_INTERFACE"
     ):
         raise AssertionError(
             "Cannot generate subduction srfs with genslip version less than 5.4.2"
         )
-    if compare_versions(genslip_version, "5") > 0:
+    if utils.compare_versions(genslip_version, "5") > 0:
         # Positive so version greater than 5
         logger.debug(
             f"Using genslip version {genslip_version}. Using nstk and ndip and rup_delay (for type 4)"

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -219,7 +219,7 @@ def create_info_file(
 
     if file_name is None:
         file_name = srf_file.replace(".srf", ".info")
-    logger.debug("Saving info file to {}".format(file_name))
+    logger.debug(f"Saving info file to {file_name}")
     with h5open(file_name, "w") as h:
         a = h.attrs
         # only taken from given parameters
@@ -616,22 +616,11 @@ def create_multi_plane_srf(
     with NamedTemporaryFile(mode="w", delete=False) as gsfp, NamedTemporaryFile(
         mode="w", delete=False
     ) as gsf_file:
-        rel_logger.debug("Saving segments file to {}".format(gsfp.name))
-        gsfp.write("{}\n".format(plane_count))
+        rel_logger.debug(f"Saving segments file to {gsfp.name}")
+        gsfp.write(f"{plane_count}\n")
         for f in range(plane_count):
             gsfp.write(
-                "{:f} {:f} {:f} {:.4f} {:.4f} {:.4f} {:.4f} {:.4f} {:d} {:d}\n".format(
-                    clon[f],
-                    clat[f],
-                    dtop,
-                    strike[f],
-                    dip,
-                    rake,
-                    flen[f],
-                    fwid[f],
-                    nx[f],
-                    ny,
-                )
+                f"{clon[f]} {clat[f]} {dtop} {strike[f]:.4f} {dip:.4f} {rake:.4f} {flen[f]:.4f} {fwid[f]:.4f} {nx[f]} {ny}\n"
             )
         rel_logger.debug(f"Gsf will be saved to the temporary file {gsf_file.name}")
         cmd = [
@@ -779,12 +768,12 @@ def write_corners(filename: str, hypocentre: np.ndarray, corners: np.ndarray):
     with open(filename, "w") as cf:
         # lines beginning with '>' are ignored
         cf.write(CORNERS_HEADER[0])
-        cf.write("{:f} {:f}\n".format(*hypocentre))
+        cf.write(f"{hypocentre[0]} {hypocentre[1]}\n")
         cf.write(CORNERS_HEADER[1])
         # 0 1 - draw in order to close box
         # 2 3
         for i in [0, 1, 3, 2, 0]:
-            cf.write("{:f} {:f}\n".format(*corners[i]))
+            cf.write(f"{corners[i, 0]:f} {corners[i, 1]:f}\n")
 
 
 def gen_srf(
@@ -850,9 +839,7 @@ def gen_srf(
     if compare_versions(genslip_version, "5") > 0:
         # Positive so version greater than 5
         logger.debug(
-            "Using genslip version {}. Using nstk and ndip and rup_delay (for type 4)".format(
-                genslip_version
-            )
+            f"Using genslip version {genslip_version}. Using nstk and ndip and rup_delay (for type 4)"
         )
         xstk = "nstk"
         ydip = "ndip"
@@ -860,9 +847,7 @@ def gen_srf(
     else:
         # Not positive so version at most 5
         logger.debug(
-            "Using genslip version {}. Using nx and ny and rupture_delay (for type 4)".format(
-                genslip_version
-            )
+            f"Using genslip version {genslip_version}. Using nx and ny and rupture_delay (for type 4)"
         )
         xstk = "nx"
         ydip = "ny"
@@ -890,15 +875,15 @@ def gen_srf(
     if type == 4:
         cmd.extend(
             [
-                f"seg_delay={0}",
+                "seg_delay={0}",
                 f"nseg={fault_planes}",
                 f"nseg_bounds={fault_planes - 1}",
                 f"xseg={xseg}",
-                f"rvfac_seg=-1",
-                f"gwid=-1",
-                f"side_taper=0.02",
-                f"bot_taper=0.02",
-                f"top_taper=0.0",
+                "rvfac_seg=-1",
+                "gwid=-1",
+                "side_taper=0.02",
+                "bot_taper=0.02",
+                "top_taper=0.0",
                 f"{rup_name}=0",
             ]
         )
@@ -916,7 +901,7 @@ def gen_srf(
             ]
         )
         if risetime_coef is None:
-            cmd.append(f"risetime_coef=1.95")
+            cmd.append("risetime_coef=1.95")
     if rvfac is not None:
         cmd.append(f"rvfrac={rvfac}")
     if rough is not None:
@@ -926,9 +911,9 @@ def gen_srf(
     if risetime_coef is not None:
         cmd.append(f"risetime_coef={risetime_coef}")
     if asperity_file is not None:
-        cmd.append(f"read_slip_file=1")
+        cmd.append("read_slip_file=1")
         cmd.append(f"init_slip_file={asperity_file}")
-    logger.debug("Creating SRF with command: {}".format(" ".join(cmd)))
+    logger.debug(f"Creating SRF with command: {' '.join(cmd)}")
     with open(srf_file, "w") as srfp:
         proc = run(cmd, stdout=srfp, stderr=PIPE, check=True)
     logger.debug(f"{genslip_bin} stderr: {proc.stderr}")
@@ -1020,7 +1005,7 @@ def generate_sim_params_yaml(
     logger.debug(f"Saving sim params to {sim_params_file}")
     with open(sim_params_file, "w") as spf:
         yaml.dump(sim_params, spf)
-    logger.debug(f"Sim params saved")
+    logger.debug("Sim params saved")
 
 
 def load_args() -> argparse.Namespace:
@@ -1050,7 +1035,7 @@ def main():
     else:
         raise ValueError(
             f"Type {realisation['type']} faults are not currently supported. "
-            f"Contact the software team if you believe this is an error."
+            "Contact the software team if you believe this is an error."
         )
     sim_params_file = args.realisation_file.replace(".csv", ".yaml")
     generate_sim_params_yaml(sim_params_file, realisation)

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -1,3 +1,30 @@
+"""
+This script takes converts one realisation CSV file to an SRF output file. The
+parameters of the realisation are loaded into a dictionary and stored as follows:
+
+- type: The realisation type (1, 2, 3, 4)
+- magnitude: The magnitude of the realisation
+- name: The name of the realisation.
+- longitude: The longitude of the hypocentre.
+- latitidue: The latitude of the hypocentre.
+- strike: The strike angle of the fault.
+- rake: The rake angle of the fault.
+- dip: The dip angle of the fault.
+- depth: The depth of the hypocentre.
+- flen: Fault length TODO.
+- fwid: Fault width TODO.
+- dlen: TODO
+- dwid: TODO
+- dtop: TODO
+- shypo: TODO
+- mwsr: The magnitude scaling technique.
+- dbottom: TODO
+- dt: Timestep TODO
+- seed: TODO
+- genslip_version: The genslip binary version to use
+- srfgen_seed: TODO
+"""
+
 import argparse
 from logging import Logger
 from os import makedirs, path
@@ -43,18 +70,36 @@ CORNERS_HEADER = (
 )
 
 
-def get_n(fault_size, sub_fault_size):
-    return int(round(fault_size / sub_fault_size))
+def get_n(fault_size: float, sub_fault_size: float) -> int:
+    """Get the number of subfaults for simulation TODO
+
+    Parameters
+    ----------
+    fault_size: Size of the fault.
+    sub_fault_size: Size of the subfaults.
+
+    Returns
+    -------
+    The number of subfaults within the fault. TODO
+    """
+    return round(fault_size / sub_fault_size)
 
 
 def create_stoch(
-    stoch_file,
-    srf_file,
-    single_segment=False,
+    stoch_file: str,
+    srf_file: str,
+    single_segment: bool = False,
     logger: Logger = qclogging.get_basic_logger(),
 ):
     """
-    Creates stoch file from srf file.
+    Creates a stoch file from a srf file.
+
+    Parameters
+    ----------
+    stoch_file: The filepath to output the stoch file.
+    srf_file: The filepath of the SRF file
+    single_segment: TODO
+    logger: optional alternative logger for log output.
     """
     logger.debug("Generating stoch file")
     out_dir = path.dirname(stoch_file)
@@ -74,8 +119,12 @@ def create_stoch(
     logger.debug(f"{srf2stoch} stderr: {proc.stderr}")
 
 
-def get_corners_dbottom(planes, dip_dir=None):
+def get_corners_dbottom(planes: dict, dip_dir: Union[str, None] = None):
     """
+    TODO
+
+    Parameters
+    ----------
     planes: a list of dictionaries where each dictionary is structured like below.
      {
         "centre": [float(elon), float(elat)],
@@ -119,28 +168,48 @@ def get_corners_dbottom(planes, dip_dir=None):
 
 
 def create_info_file(
-    srf_file,
-    srf_type,
-    mag,
-    rake,
-    dt,
-    vm=None,
-    vs=None,
-    rho=None,
-    centroid_depth=None,
-    lon=None,
-    lat=None,
-    shypo=None,
-    dhypo=None,
-    mwsr=None,
-    tect_type=None,
-    dip_dir=None,
-    file_name=None,
+    srf_file: str,
+    srf_type: int,
+    mag: float,
+    rake: float,
+    dt: float,
+    vm: Union[float, None] = None,
+    vs: Union[float, None] = None,
+    rho: Union[float, None] = None,
+    centroid_depth: Union[float, None] = None,
+    lon: Union[float, None] = None,
+    lat: Union[float, None] = None,
+    shypo: Union[float, None] = None,
+    dhypo: Union[float, None] = None,
+    mwsr: Union[MagnitudeScalingRelations, None] = None,
+    tect_type: Union[str, None] = None,
+    dip_dir: Union[str, None] = None,
+    file_name: Union[str, None] = None,
     logger: Logger = qclogging.get_basic_logger(),
 ):
     """
-    Stores SRF metadata as hdf5.
-    srf_file: SRF path used as basename for info file and additional metadata
+    Store SRF metadata as hdf5.
+
+    Parameters
+    ----------
+    srf_file: SRF path used as basename for info file and additional metadata.
+    srf_type: Realisation type (e.g. 1, 2, 3, or 4).
+    mag: Magnitude of the realisation.
+    rake: Rake of the fault.
+    dt: TODO
+    vm: TODO
+    vs: TODO
+    rho: TODO
+    centroid_depth: Depth of the hypocentre.
+    lon: longitude of the hypocentre.
+    lat: latitude of the hypocentre.
+    shypo: TODO |
+    dhypo: TODO | Something to do with the hypocentre
+    mwsr: Magnitude scaling method. See mag_scaling in qcore.
+    tect_type: Type of the interface (e.g. 'SUBDUCTION_INTERFACE')
+    dip_dir: TODO | Directory of something?
+    file_name: File path to save metadata
+    logger: Logger for debug output
     """
     logger.debug("Generating srf info file")
     planes = srf.read_header(srf_file, idx=True)
@@ -190,6 +259,16 @@ def create_ps_srf(
     stoch_file: Union[None, str] = None,
     logger: Logger = qclogging.get_basic_logger,
 ):
+    """Generate SRF file (point source modeling)
+
+    Parameters
+    ----------
+    realisation_file: Path to the realisation (a CSV file). The output files (srf, stoch, etc) are produced relative to this file path.
+    parameter_dictionary: Parameters of the realisation. See module documentation for a description of these parameters.
+    stoch_file: An optional alternative location for the stoch file.
+    logger: optional alternative logger for log output.
+    """
+
     latitude = parameter_dictionary.pop("latitude")
     longitude = parameter_dictionary.pop("longitude")
     depth = parameter_dictionary.pop("depth")
@@ -319,6 +398,16 @@ def create_ps_ff_srf(
     stoch_file: Union[None, str] = None,
     logger: Logger = qclogging.get_basic_logger,
 ):
+    """Generate SRF file (point source finite fault modeling)
+
+    Parameters
+    ----------
+    realisation_file: Path to the realisation (a CSV file). The output files (srf, stoch, etc) are produced relative to this file path.
+    parameter_dictionary: Parameters of the realisation. See module documentation for a description of these parameters.
+    stoch_file: An optional alternative location for the stoch file.
+    logger: optional alternative logger for log output.
+    """
+
     name = parameter_dictionary.get("name")
     logger.info(f"Generating srf for realisation {name}")
 
@@ -442,6 +531,16 @@ def create_multi_plane_srf(
     stoch_file: Union[None, str] = None,
     logger: Logger = qclogging.get_basic_logger(),
 ):
+    """Generate SRF file (multi-plane source modeling)
+
+    Parameters
+    ----------
+    realisation_file: Path to the realisation (a CSV file). The output files (srf, stoch, etc) are produced relative to this file path.
+    parameter_dictionary: Parameters of the realisation. See module documentation for a description of these parameters.
+    stoch_file: An optional alternative location for the stoch file.
+    logger: optional alternative logger for log output.
+    """
+
     name = parameter_dictionary.get("name")
     rel_logger = qclogging.get_realisation_logger(logger, name)
     rel_logger.info(f"Generating srf for realisation {name}")
@@ -610,11 +709,34 @@ def create_multi_plane_srf(
     return srf_file
 
 
-def get_corners(lat, lon, flen, fwid, dip, strike):
+def get_corners(
+    lat: float, lon: float, flen: float, fwid: float, dip: float, strike: float
+) -> np.ndarray:
     """
-    Return Corners of a fault. Indexes are as below.
-    0 1
-    2 3
+    Get the corners of a finite-fault plane generated from a point-source specified in the WGS84 coordinate system.
+
+    Parameters
+    ---------
+    lat: The latitude of the point source.
+    lon: The longitude of the point source.
+    flen: The length of the fault.
+    fwid: The width of the fault.
+    dip: The dip angle of the fault.
+    strike: The strike angle of the fault.
+
+    Returns
+    -------
+    A numpy array containing the corners of a fault. The values of the array are
+    (lon, lat) pairs  representing coordinates in the WGS84 coordinate system.
+    The indices 0, 1, 2, 3 correspond to the corners of the fault in the
+    following fashion.
+                  fwid
+            0 +------------+ 1
+              |            |
+              |            |
+              |            | flen
+              |            |
+            2 +------------+ 3
     """
     lats, lons = calculate_corners(
         dip,
@@ -629,9 +751,30 @@ def get_corners(lat, lon, flen, fwid, dip, strike):
     return np.dstack((lons.flat, lats.flat))[0]
 
 
-def write_corners(filename, hypocentre, corners):
+def write_corners(filename: str, hypocentre: np.ndarray, corners: np.ndarray):
     """
     Write a corners text file (used to plot faults).
+
+    The format of the corners file given a hypocentre [lonc, latc] an array of corners [[lon0, lat0], ..., [lon3, lat3]] is as follows
+
+    ```
+    OUTPUT_PREHEADER # see CORNERS_HEADER[0]
+    lonc latc
+    OUTPUT_CORNERS_HEADER # see CORNERS_HEADER[1]
+    lon0 lat0
+    lon1 lat1
+    lon2 lat2
+    lon3 lat3
+    lon0 lat0
+    ```
+
+    The "#"'s are informational comments for documentation and not written to the file.
+
+    Parameters
+    ----------
+    filename: The filepath to write the corners to.
+    hypocentre: The hypocentre of the eruption.
+    corners: The bounds of the finite fault (as described in `get_corners`)
     """
     with open(filename, "w") as cf:
         # lines beginning with '>' are ignored
@@ -645,32 +788,56 @@ def write_corners(filename, hypocentre, corners):
 
 
 def gen_srf(
-    srf_file,
-    gsf_file,
-    type,
-    magnitude,
-    dt,
-    nx,
-    ny,
-    seed,
-    shypo,
-    dhypo,
-    velocity_model,
-    genslip_version="3.3",
-    rvfac=None,
-    rough=0.0,
-    slip_cov=None,
-    risetime_coef=None,
-    tect_type=None,
-    fault_planes=1,
-    asperity_file=None,
+    srf_file: str,
+    gsf_file: str,
+    type: int,
+    magnitude: float,
+    dt: float,
+    nx: float,
+    ny: float,
+    seed: int,
+    shypo: float,
+    dhypo: float,
+    velocity_model: str,
+    genslip_version: str = "3.3",
+    rvfac: Union[float, None] = None,
+    rough: float = 0.0,
+    slip_cov: Union[float, None] = None,
+    risetime_coef: Union[float, None] = None,
+    tect_type: Union[str, None] = None,
+    fault_planes: int = 1,
+    asperity_file: Union[str, None] = None,
     xseg: Union[float, List[float]] = "-1",
     logger: Logger = qclogging.get_basic_logger(),
 ):
     """
-    :param xseg: Genslip parameter:
-        For multi plane arrays the length (along strike) of each plane. -1 for single plane.
-        Deprecated in genslip 5.4.2, ignored if present
+    Wrapper around genslip, which actually generates the SRF files. The
+    arguments to this function are validated and passed to genslip as command
+    line arguments in a subprocess.
+
+    Parameters
+    ----------
+    srf_file: The output srf file.
+    gsf_file: The input gsf file (TODO).
+    type: The type the source model.
+    magnitude: The magnitude of the event.
+    dt: TODO
+    nx: TODO
+    ny: TODO
+    seed: TODO
+    shypo: TODO | Involved with the hypocentre?
+    dhypo: TODO |
+    velocity_model: path to velocity model.
+    genslip_version: The version of genslip to use.
+    rvfac: TODO
+    rough: TODO
+    slip_cov: TODO
+    risetime_coef: TODO
+    tect_type: TODO
+    fault_planes: TODO | Number of fault planes?
+    asperity_file: TODO?
+    xseg: TODO | Segments for type 4 simulations?
+    logger: optional alternative logger for log output.
     """
     genslip_bin = binary_version.get_genslip_bin(genslip_version)
     if (
@@ -781,6 +948,23 @@ def gen_gsf(
     ny,
     logger: Logger = qclogging.get_basic_logger(),
 ):
+    """Wrapper around the fault_seg2gsf_dipdir binary.
+
+    Parameters
+    ----------
+    gsfp: File path for the GSF file.
+    lon: hypocentre longitude TODO
+    lat: hypocentre latitude TODO
+    dtop: TODO
+    strike: strike angle of the fault.
+    dip: dip angle of the fault.
+    rake: rake angle of the fault.
+    flen: length of the fault.
+    fwid: width of the fault.
+    nx: TODO
+    ny: TODO
+    logger: optional alternative logger for log output.
+    """
     logger.debug(f"Saving gsf to {gsfp.name}")
     gexec = Popen(
         [binary_version.get_unversioned_bin(FAULTSEG2GSFDIPDIR), "read_slip_vals=0"],
@@ -800,6 +984,14 @@ def generate_sim_params_yaml(
     parameters: Dict[str, Any],
     logger: Logger = qclogging.get_basic_logger(),
 ):
+    """Write simulation parameters to a yaml file.
+
+    Parameters
+    ----------
+    sim_params_file: The filepath to save the simulation parameters.
+    parameters: The parameters to save.
+    logger: optional alternative logger for log output.
+    """
     makedirs(path.dirname(sim_params_file), exist_ok=True)
 
     logger.debug(f"Raw sim params: {parameters}")
@@ -831,7 +1023,13 @@ def generate_sim_params_yaml(
     logger.debug(f"Sim params saved")
 
 
-def load_args():
+def load_args() -> argparse.Namespace:
+    """Parse command lines arguments.
+
+    Returns
+    -------
+    A Namespace object containing the command line arguments (as specified by parse_args).
+    """
     parser = argparse.ArgumentParser()
     parser.add_argument("realisation_file", type=path.abspath)
     return parser.parse_args()

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -621,9 +621,9 @@ def create_multi_plane_srf(
         if int(plane_count > 1):
             rel_logger.debug("Multiple segments detected. Generating xseg argument")
             flen_array = np.asarray(flen)
-            xseg = ",".join(map(str, flen_array.cumsum() - flen_array / 2))
+            xseg = flen_array.cumsum() - flen_array / 2
         else:
-            xseg = "-1"
+            xseg = [-1]
 
         gen_srf(
             srf_file,
@@ -774,7 +774,7 @@ def gen_srf(
     tect_type: Union[str, None] = None,
     fault_planes: int = 1,
     asperity_file: Union[str, None] = None,
-    xseg: Union[float, List[float]] = "-1",
+    xseg: List[float] = [-1],
     logger: Logger = qclogging.get_basic_logger(),
 ):
     """
@@ -855,12 +855,13 @@ def gen_srf(
         "srf_version=1.0",
     ]
     if type == 4:
+        xseg_array = ",".join(str(seg) for seg in xseg)
         cmd.extend(
             [
                 "seg_delay={0}",
                 f"nseg={fault_planes}",
                 f"nseg_bounds={fault_planes - 1}",
-                f"xseg={xseg}",
+                f"xseg={xseg_array}",
                 "rvfac_seg=-1",
                 "gwid=-1",
                 "side_taper=0.02",

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -910,17 +910,17 @@ def gen_srf(
 
 
 def gen_gsf(
-    gsfp,
-    lon,
-    lat,
-    dtop,
-    strike,
-    dip,
-    rake,
-    flen,
-    fwid,
-    nx,
-    ny,
+    gsfp: str,
+    lon: float,
+    lat: float,
+    dtop: float,
+    strike: float,
+    dip: float,
+    rake: float,
+    flen: float,
+    fwid: float,
+    nx: float,
+    ny: float,
     logger: Logger = qclogging.get_basic_logger(),
 ):
     """Wrapper around the fault_seg2gsf_dipdir binary.

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -8,6 +8,7 @@ The parameters that are read from the CSV file are documented on the
 import argparse
 import os
 import subprocess
+from subprocess import Popen
 from logging import Logger
 from tempfile import NamedTemporaryFile
 from typing import Any, Dict, List, TextIO, Union, Tuple
@@ -15,7 +16,10 @@ from typing import Any, Dict, List, TextIO, Union, Tuple
 import numpy as np
 import yaml
 import h5py
-import qcore
+from qcore import binary_version, geo, qclogging, srf, utils
+from qcore.uncertainties import mag_scaling
+from qcore.uncertainties.mag_scaling import MagnitudeScalingRelations
+from qcore.utils import compare_versions
 from srf_generation import pre_processing_common
 from srf_generation.source_parameter_generation.common import (
     DEFAULT_1D_VELOCITY_MODEL_PATH,
@@ -64,7 +68,7 @@ def create_stoch(
     stoch_file: str,
     srf_file: str,
     single_segment: bool = False,
-    logger: Logger = qcore.qclogging.get_basic_logger(),
+    logger: Logger = qclogging.get_basic_logger(),
 ):
     """Create a stoch file from a SRF file.
 
@@ -84,10 +88,10 @@ def create_stoch(
     out_dir = os.path.dirname(stoch_file)
     os.makedirs(out_dir, exist_ok=True)
     dx, dy = 2.0, 2.0
-    if not qcore.srf.is_ff(srf_file):
-        dx, dy = qcore.srf.srf_dxy(srf_file)
+    if not srf.is_ff(srf_file):
+        dx, dy = srf.srf_dxy(srf_file)
     logger.debug(f"Saving stoch to {stoch_file}")
-    srf2stoch = qcore.binary_version.get_unversioned_bin(SRF2STOCH)
+    srf2stoch = binary_version.get_unversioned_bin(SRF2STOCH)
     if single_segment:
         command = [srf2stoch, f"target_dx={dx}", f"target_dy={dy}"]
     else:
@@ -134,18 +138,18 @@ def get_corners_dbottom(
 
         # projected fault width (along dip direction)
         pwid = p["width"] * np.cos(np.radians(p["dip"]))
-        corners[i, 0] = qcore.geo.ll_shift(
+        corners[i, 0] = geo.ll_shift(
             p["centre"][1], p["centre"][0], p["length"] / 2.0, p["strike"] + 180
         )[::-1]
-        corners[i, 1] = qcore.geo.ll_shift(
+        corners[i, 1] = geo.ll_shift(
             p["centre"][1], p["centre"][0], p["length"] / 2.0, p["strike"]
         )[::-1]
-        corners[i, 2] = qcore.geo.ll_shift(
-            corners[i, 1, 1], corners[i, 1, 0], pwid, dip_deg
-        )[::-1]
-        corners[i, 3] = qcore.geo.ll_shift(
-            corners[i, 0, 1], corners[i, 0, 0], pwid, dip_deg
-        )[::-1]
+        corners[i, 2] = geo.ll_shift(corners[i, 1, 1], corners[i, 1, 0], pwid, dip_deg)[
+            ::-1
+        ]
+        corners[i, 3] = geo.ll_shift(corners[i, 0, 1], corners[i, 0, 0], pwid, dip_deg)[
+            ::-1
+        ]
         dbottom.append(p["dtop"] + p["width"] * np.sin(np.radians(p["dip"])))
 
     return (corners, dbottom)

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -597,8 +597,11 @@ def create_multi_plane_srf(
         gsfp.write(f"{plane_count}\n")
         for f in range(plane_count):
             gsfp.write(
-                f"{clon[f]} {clat[f]} {dtop} {strike[f]:.4f} {dip:.4f} {rake:.4f} {flen[f]:.4f} {fwid[f]:.4f} {nx[f]} {ny}\n"
+                f"{clon[f]:6f} {clat[f]:6f} {dtop:6f} {strike[f]:.4f} {dip:.4f} {rake:.4f} {flen[f]:.4f} {fwid[f]:.4f} {nx[f]:d} {ny:d}\n"
             )
+        # NOTE: This flush call is vital. It ensures that the input file for fault_seg_bin actually contains input for fault_seg_bin to read.
+        # without this, genslip will segfault later.
+        gsfp.flush()
         rel_logger.debug(f"Gsf will be saved to the temporary file {gsf_file.name}")
         cmd = [
             fault_seg_bin,

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -1,28 +1,8 @@
 """
-This script takes converts one realisation CSV file to an SRF output file. The
-parameters of the realisation are loaded into a dictionary and stored as follows:
+This script takes converts one realisation CSV file to an SRF output file.
 
-- type: The realisation type (1, 2, 3, 4)
-- magnitude: The magnitude of the realisation
-- name: The name of the realisation.
-- longitude: The longitude of the hypocentre.
-- latitidue: The latitude of the hypocentre.
-- strike: The strike angle of the fault.
-- rake: The rake angle of the fault.
-- dip: The dip angle of the fault.
-- depth: The depth of the hypocentre.
-- flen: Fault length TODO.
-- fwid: Fault width TODO.
-- dlen: TODO
-- dwid: TODO
-- dtop: TODO
-- shypo: TODO
-- mwsr: The magnitude scaling technique.
-- dbottom: TODO
-- dt: Timestep TODO
-- seed: TODO
-- genslip_version: The genslip binary version to use
-- srfgen_seed: TODO
+The parameters that are read from the CSV file are documented on the
+[wiki](https://wiki.canterbury.ac.nz/display/QuakeCore/File+Formats+Used+On+GM).
 """
 
 import argparse
@@ -92,7 +72,7 @@ def create_stoch(
     logger: Logger = qclogging.get_basic_logger(),
 ):
     """
-    Creates a stoch file from a srf file.
+    Create a stoch file from a srf file.
 
     Parameters
     ----------
@@ -194,19 +174,21 @@ def create_info_file(
     ----------
     srf_file: SRF path used as basename for info file and additional metadata.
     srf_type: Realisation type (e.g. 1, 2, 3, or 4).
-    mag: Magnitude of the realisation.
-    rake: Rake of the fault.
-    dt: TODO
-    vm: TODO
-    vs: TODO
-    rho: TODO
-    centroid_depth: Depth of the hypocentre.
-    lon: longitude of the hypocentre.
-    lat: latitude of the hypocentre.
-    shypo: TODO |
-    dhypo: TODO | Something to do with the hypocentre
-    mwsr: Magnitude scaling method. See mag_scaling in qcore.
-    tect_type: Type of the interface (e.g. 'SUBDUCTION_INTERFACE')
+
+    mag           |
+    rake          |
+    dt            |
+    vm            |
+    vs            |
+    rho           | Refer to wiki (see module documentation for link).
+    mwsr          |
+    tect_type     |
+    centroid_depth|
+    shypo         |
+    dhypo         |
+
+    lon: longitude of the centroid.
+    lat: latitude of the centroid.
     dip_dir: TODO | Directory of something?
     file_name: File path to save metadata
     logger: Logger for debug output
@@ -259,16 +241,18 @@ def create_ps_srf(
     stoch_file: Union[None, str] = None,
     logger: Logger = qclogging.get_basic_logger,
 ):
-    """Generate SRF file (point source modeling)
+    """
+    Generate SRF file (point source modeling).
 
     Parameters
     ----------
-    realisation_file: Path to the realisation (a CSV file). The output files (srf, stoch, etc) are produced relative to this file path.
-    parameter_dictionary: Parameters of the realisation. See module documentation for a description of these parameters.
+    realisation_file: Path to the realisation (a CSV file). The output files
+    (srf, stoch, etc) are produced relative to this file path.
+    parameter_dictionary: Parameters of the realisation. See module
+    documentation for a description of these parameters.
     stoch_file: An optional alternative location for the stoch file.
     logger: optional alternative logger for log output.
     """
-
     latitude = parameter_dictionary.pop("latitude")
     longitude = parameter_dictionary.pop("longitude")
     depth = parameter_dictionary.pop("depth")
@@ -706,12 +690,12 @@ def get_corners(
 
     Parameters
     ---------
-    lat: The latitude of the point source.
-    lon: The longitude of the point source.
-    flen: The length of the fault.
-    fwid: The width of the fault.
-    dip: The dip angle of the fault.
-    strike: The strike angle of the fault.
+    lat   |
+    lon   |
+    flen  |
+    fwid  | Refer to wiki (see module documentation for link).
+    dip   |
+    strike|
 
     Returns
     -------
@@ -800,32 +784,36 @@ def gen_srf(
     logger: Logger = qclogging.get_basic_logger(),
 ):
     """
-    Wrapper around genslip, which actually generates the SRF files. The
-    arguments to this function are validated and passed to genslip as command
+    Wrapper around genslip, which actually generates the SRF files.
+
+    The arguments to this function are validated and passed to genslip as command
     line arguments in a subprocess.
 
     Parameters
     ----------
     srf_file: The output srf file.
     gsf_file: The input gsf file (TODO).
-    type: The type the source model.
-    magnitude: The magnitude of the event.
-    dt: TODO
-    nx: TODO
-    ny: TODO
-    seed: TODO
-    shypo: TODO | Involved with the hypocentre?
-    dhypo: TODO |
-    velocity_model: path to velocity model.
-    genslip_version: The version of genslip to use.
-    rvfac: TODO
-    rough: TODO
-    slip_cov: TODO
-    risetime_coef: TODO
-    tect_type: TODO
-    fault_planes: TODO | Number of fault planes?
-    asperity_file: TODO?
+
+    type           |
+    magnitude      |
+    dt             |
+    nx             |
+    ny             |
+    seed           |
+    shypo          |
+    dhypo          |
+    velocity_model | Refer to wiki (see module documentation for link).
+    genslip_version|
+    rvfac          |
+    rough          |
+    slip_cov       |
+    risetime_coef  |
+    tect_type      |
+
+    fault_planes:  TODO | Number of fault planes?
+    asperity_file: TODO
     xseg: TODO | Segments for type 4 simulations?
+
     logger: optional alternative logger for log output.
     """
     genslip_bin = binary_version.get_genslip_bin(genslip_version)
@@ -938,14 +926,16 @@ def gen_gsf(
     Parameters
     ----------
     gsfp: File path for the GSF file.
-    lon: hypocentre longitude TODO
-    lat: hypocentre latitude TODO
-    dtop: TODO
-    strike: strike angle of the fault.
-    dip: dip angle of the fault.
-    rake: rake angle of the fault.
-    flen: length of the fault.
-    fwid: width of the fault.
+
+    lon   |
+    lat   |
+    dtop  |
+    strike| Refer to wiki (see module documentation for link).
+    dip   |
+    rake  |
+    flen  |
+    fwid  |
+
     nx: TODO
     ny: TODO
     logger: optional alternative logger for log output.

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -943,17 +943,16 @@ def gen_gsf(
     logger: optional alternative logger for log output.
     """
     logger.debug(f"Saving gsf to {gsfp.name}")
-    gexec = Popen(
+    with Popen(
         [binary_version.get_unversioned_bin(FAULTSEG2GSFDIPDIR), "read_slip_vals=0"],
         stdin=PIPE,
         stdout=gsfp,
-    )
-    gexec.communicate(
-        f"1\n{lon:f} {lat:f} {dtop:f} {strike} {dip} {rake} {flen:f} {fwid:f} {nx:d} {ny:d}".encode(
-            "utf-8"
+    ) as gexec:
+        gexec.communicate(
+            f"1\n{lon:f} {lat:f} {dtop:f} {strike} {dip} {rake} {flen:f} {fwid:f} {nx:d} {ny:d}".encode(
+                "utf-8"
+            )
         )
-    )
-    gexec.wait()
 
 
 def generate_sim_params_yaml(

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -5,7 +5,6 @@ The parameters that are read from the CSV file are documented on the
 [wiki](https://wiki.canterbury.ac.nz/display/QuakeCore/File+Formats+Used+On+GM).
 """
 
-from pathlib import Path
 import argparse
 import os
 import subprocess

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -122,13 +122,13 @@ def get_corners_dbottom(planes: Dict[str, Any], dip_dir: Union[str, None] = None
     dbottom = []
     corners = np.zeros((len(planes), 4, 2))
     for i, p in enumerate(planes):
-        # currently only support single dip dir value
+        # currently only support single dip dir value TODO: is this true?
         if dip_dir is not None:
             dip_deg = dip_dir
         else:
             dip_deg = p["strike"] + 90
 
-        # projected fault width (along dip direction)
+        # projected fault width (along dip direction) TODO: more descriptive comment here (but it does need a comment)
         pwid = p["width"] * np.cos(np.radians(p["dip"]))
         corners[i, 0] = geo.ll_shift(
             p["centre"][1], p["centre"][0], p["length"] / 2.0, p["strike"] + 180
@@ -204,7 +204,7 @@ def create_info_file(
     logger.debug(f"Saving info file to {file_name}")
     with h5open(file_name, "w") as h:
         a = h.attrs
-        # only taken from given parameters
+        # only taken from given parameters TODO: ???
         a["type"] = srf_type
         a["dt"] = dt
         a["rake"] = rake
@@ -286,7 +286,8 @@ def create_ps_srf(
         logger.debug("moment is negative, calculating from magnitude")
         moment = mag2mom(magnitude)
 
-    # size (dd) and slip
+    # size (dd) and slip TODO: what is this comment saying?
+    # TODO: Why is this random calculation here?
     if target_area_km is not None:
         logger.debug(
             f"target_area_km given ({target_area_km}), using it to calculate fault edge length and slip"
@@ -395,7 +396,6 @@ def create_ps_ff_srf(
     name = parameter_dictionary.get("name")
     logger.info(f"Generating srf for realisation {name}")
 
-    # pops
     latitude = parameter_dictionary.pop("latitude")
     longitude = parameter_dictionary.pop("longitude")
     depth = parameter_dictionary.pop("depth")
@@ -425,7 +425,6 @@ def create_ps_ff_srf(
 
     mwsr = MagnitudeScalingRelations(parameter_dictionary.pop("mwsr"))
 
-    # gets
     rvfac = parameter_dictionary.get("rvfac", None)
 
     logger.debug(
@@ -486,7 +485,6 @@ def create_ps_ff_srf(
         stoch_file = realisation_file.replace(".csv", ".stoch")
     create_stoch(stoch_file, srf_file, single_segment=True, logger=logger)
 
-    # save INFO
     create_info_file(
         srf_file,
         2,
@@ -529,7 +527,6 @@ def create_multi_plane_srf(
     rel_logger = qclogging.get_realisation_logger(logger, name)
     rel_logger.info(f"Generating srf for realisation {name}")
 
-    # pops
     magnitude = parameter_dictionary.pop("magnitude")
     moment = parameter_dictionary.pop("moment")
     rake = parameter_dictionary.pop("rake")
@@ -568,7 +565,6 @@ def create_multi_plane_srf(
         if "_subfault_" in key:
             parameter_dictionary.pop(key)
 
-    # gets
     vel_mod_1d = parameter_dictionary.pop(
         "srf_vel_mod_1d", DEFAULT_1D_VELOCITY_MODEL_PATH
     )
@@ -659,7 +655,6 @@ def create_multi_plane_srf(
 
     rel_logger.info("stoch created, making info")
 
-    # save INFO
     create_info_file(
         srf_file,
         4,
@@ -754,7 +749,7 @@ def write_corners(filename: str, hypocentre: np.ndarray, corners: np.ndarray):
         cf.write(f"{hypocentre[0]} {hypocentre[1]}\n")
         cf.write(CORNERS_HEADER[1])
         # 0 1 - draw in order to close box
-        # 2 3
+        # 2 3 TODO: bad explanation of the file format
         for i in [0, 1, 3, 2, 0]:
             cf.write(f"{corners[i, 0]:f} {corners[i, 1]:f}\n")
 

--- a/srf_generation/source_parameter_generation/uncertainties/versions/V19p8.py
+++ b/srf_generation/source_parameter_generation/uncertainties/versions/V19p8.py
@@ -1,4 +1,5 @@
 """A basic perturbator as an example and starting point"""
+
 from typing import Any, Dict
 
 from pandas import DataFrame

--- a/srf_generation/source_parameter_generation/uncertainties/versions/cs_20_4.py
+++ b/srf_generation/source_parameter_generation/uncertainties/versions/cs_20_4.py
@@ -1,4 +1,5 @@
 """A basic perturbator as an example and starting point"""
+
 from typing import Any, Dict
 import copy
 

--- a/srf_generation/source_parameter_generation/uncertainties/versions/feature_showcase.py
+++ b/srf_generation/source_parameter_generation/uncertainties/versions/feature_showcase.py
@@ -1,4 +1,5 @@
 """A basic perturbator as an example and starting point"""
+
 import pandas as pd
 from typing import Any, Dict
 

--- a/srf_generation/source_parameter_generation/uncertainties/versions/gcmt_1.py
+++ b/srf_generation/source_parameter_generation/uncertainties/versions/gcmt_1.py
@@ -1,4 +1,5 @@
 """A basic perturbator as an example and starting point"""
+
 import pandas as pd
 from typing import Any, Dict
 

--- a/srf_generation/source_parameter_generation/uncertainties/versions/gcmt_2.py
+++ b/srf_generation/source_parameter_generation/uncertainties/versions/gcmt_2.py
@@ -1,5 +1,6 @@
 """The template for future perturbation versions.
 Update this docstring with information about the version"""
+
 from typing import Any, Dict
 
 import pandas as pd

--- a/srf_generation/source_parameter_generation/uncertainties/versions/nhm_3.py
+++ b/srf_generation/source_parameter_generation/uncertainties/versions/nhm_3.py
@@ -1,4 +1,5 @@
 """A basic perturbator as an example and starting point"""
+
 import pandas as pd
 from typing import Any, Dict
 

--- a/srf_generation/source_parameter_generation/uncertainties/versions/nhm_4.py
+++ b/srf_generation/source_parameter_generation/uncertainties/versions/nhm_4.py
@@ -1,4 +1,5 @@
 """A basic perturbator as an example and starting point"""
+
 import copy
 
 from typing import Any, Dict

--- a/srf_generation/source_parameter_generation/uncertainties/versions/sjn_realisations_203.py
+++ b/srf_generation/source_parameter_generation/uncertainties/versions/sjn_realisations_203.py
@@ -1,4 +1,5 @@
 """Version 203 for Sarah Neills source parameter perturbations"""
+
 from typing import Any, Dict
 
 import numpy as np

--- a/srf_generation/velocity_model_generation/q_model_generation/EP_to_bin.py
+++ b/srf_generation/velocity_model_generation/q_model_generation/EP_to_bin.py
@@ -1,4 +1,5 @@
 """Script to generate a Qp/Qs binary model file from an Eberhart-Phillips style ascii model"""
+
 import argparse
 from os.path import abspath
 import pandas as pd

--- a/srf_generation/velocity_model_generation/q_model_generation/generate_all_qp_qs.py
+++ b/srf_generation/velocity_model_generation/q_model_generation/generate_all_qp_qs.py
@@ -1,6 +1,7 @@
 """
 To be run manually to generate all Q files for an entire simulation directory at once
 """
+
 import argparse
 from multiprocessing import pool
 from os.path import abspath


### PR DESCRIPTION
Adds documentation, type-hints, consistency checks, and clears out some python no-no's from the realisation to srf code. 

There are a number of outstanding parameters that do not currently have any documentation - because I am not sure what they are. Some input on what these are would be appreciated so I can finish the documentation of the module. Also I would appreciate someone checking my documentation does make sense; I probably misinterpreted what certain variables mean.

I also propose changing the way the parameters yaml object is created (WIP). Currently, this object is creating by taking first the realisation file and then stripping some of the fields out (which is why there is so many pop calls all over the place). This is not a very good way to do things, because it means we are destructively modifying input parameters all over the place, and because it obscures what actually gets written to the yaml file for no reason. I would propose having the functions of the form `create_ps_*` instead return the simulation parameters as a dictionary that is written to a yaml file to make things more explicit. 