### PR TITLE
Updated comment on Leonard2014

### DIFF
--- a/srf_generation/Fault.py
+++ b/srf_generation/Fault.py
@@ -495,6 +495,7 @@ class Type3(FiniteFault):
             self.mwsr = MagnitudeScalingRelations.SKARLATOUDIS2016
 
         else:
+            # Note: LEONARD2014 (stable continental region (SCR) vs LEONARD2010 (active region) but the formulation is the same
             self.mwsr = MagnitudeScalingRelations.LEONARD2014
 
         raw_fwid = (self._dbottom - dtop) / np.sin(np.radians(dip))

--- a/srf_generation/Fault.py
+++ b/srf_generation/Fault.py
@@ -495,7 +495,8 @@ class Type3(FiniteFault):
             self.mwsr = MagnitudeScalingRelations.SKARLATOUDIS2016
 
         else:
-            # Note: LEONARD2014 (stable continental region (SCR) vs LEONARD2010 (active region) but the formulation is the same
+            # Note: Leonard2010 focused on active region which is more suitable for NZ while Leonard2014 discusses SCR
+            # (stable continental region). However, the formulation is the same, and we just refer to it as Leonard2014
             self.mwsr = MagnitudeScalingRelations.LEONARD2014
 
         raw_fwid = (self._dbottom - dtop) / np.sin(np.radians(dip))


### PR DESCRIPTION
There was a discussion on Leonard2010 vs Leonard2014 on Slack in regards to what we should use for the magnitude-area relations. 
https://uceqeng.slack.com/archives/CUD9MUZ4Y/p1719447280472479

We have been using LEONARD2014 for Cybershake.

Leonard2010 is on active region and Leonard2014 is on SCR (stable continental region), so we should use & cite Leonard2010 for Cybershake NZ.

However, it happens to be the underlying math is the same. 
For the future reference, I just made a comment. 

Perhaps it is better to rename it to Leonard2010 in
https://github.com/ucgmsim/qcore/blob/master/qcore/uncertainties/mag_scaling.py 
but I feel it can be slightly risky when we currently have a Cyberhsake 200m run in progress... 
