### PR TITLE
Fix for a rel csv file given in relative path

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,6 @@ pipeline {
                     pip install -r requirements.txt
                     pip install -e .
 
-                    python setup.py develop --no-data --no-deps
                 """
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,9 @@ pipeline {
                     rm -rf qcore
                     git clone https://github.com/ucgmsim/qcore.git
                     cd qcore
+                    pip install -r requirements.txt
+                    pip install -e .
+
                     python setup.py develop --no-data --no-deps
                 """
             }
@@ -40,7 +43,7 @@ pipeline {
                     echo "[ Python used ] : " `which python`
                     cd ${env.WORKSPACE}
                     echo "[ Installing ${env.JOB_NAME} ]"
-                    python setup.py install
+		    pip install -e .
                     echo "[ Run test now ]"
                     pytest --black --ignore=geoNet --ignore=NonUniformGrid --ignore=RegionalSeismicityTectonics --ignore=SrfGen/NHM/deprecated --ignore=test
                 """

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -85,7 +85,6 @@ def create_stoch(
 
     logger.debug("Generating stoch file")
     out_dir = os.path.dirname(stoch_file)
-
     os.makedirs(out_dir, exist_ok=True)
     dx, dy = 2.0, 2.0
     if not srf.is_ff(srf_file):

--- a/srf_generation/input_file_generation/realisation_to_srf.py
+++ b/srf_generation/input_file_generation/realisation_to_srf.py
@@ -85,6 +85,7 @@ def create_stoch(
 
     logger.debug("Generating stoch file")
     out_dir = os.path.dirname(stoch_file)
+
     os.makedirs(out_dir, exist_ok=True)
     dx, dy = 2.0, 2.0
     if not srf.is_ff(srf_file):
@@ -1062,6 +1063,8 @@ def main():
     primary_logger = qclogging.get_logger("realisation_to_srf")
     qclogging.add_general_file_handler(primary_logger, "rel2srf.txt")
     args = load_args()
+    args.realisation_file = os.path.abspath(args.realisation_file)
+
     realisation = pre_processing_common.load_realisation_file_as_dict(
         args.realisation_file
     )


### PR DESCRIPTION
When you run `realisation_to_srf.py` from the path where the rel csv file is located and give a relative path (ie. just the file name), it will get confused when it sees `mkdir` because `os.path.dirname(rel_csv)` is an empty string.

```
Traceback (most recent call last):
...
  File "/home/seb56/Pre-processing/srf_generation/input_file_generation/realisation_to_srf.py", line 88, in create_stoch
    os.makedirs(out_dir, exist_ok=True)
  File "/home/seb56/miniforge3/envs/mamba310/lib/python3.10/os.py", line 225, in makedirs
    mkdir(name, mode)
FileNotFoundError: [Errno 2] No such file or directory: ''

```
or 

Traceback (most recent call last):
...
  File "/home/seb56/Pre-processing/srf_generation/input_file_generation/realisation_to_srf.py", line 1016, in generate_sim_params_yaml
    os.makedirs(os.path.dirname(sim_params_file), exist_ok=True)
  File "/home/seb56/miniforge3/envs/mamba310/lib/python3.10/os.py", line 225, in makedirs
    mkdir(name, mode)
FileNotFoundError: [Errno 2] No such file or directory: ''

